### PR TITLE
Added `visitContextBefore`/`After`

### DIFF
--- a/src/model/visitor.ts
+++ b/src/model/visitor.ts
@@ -475,13 +475,18 @@ export class Context {
   }
 
   accept(context: Context, visitor: Visitor): void {
+    visitor.visitContextBefore(context);
     context.namespaces.map((namespace) => {
       namespace.accept(context.clone({ namespace: namespace }), visitor);
     });
+    visitor.visitContextAfter(context);
   }
 }
 
 export interface Visitor {
+  visitContextBefore(context: Context): void;
+  visitContextAfter(context: Context): void;
+
   visitNamespaceBefore(context: Context): void;
   visitNamespace(context: Context): void;
   visitNamespaceAfter(context: Context): void;
@@ -580,6 +585,20 @@ export abstract class AbstractVisitor implements Visitor {
       const callback = purposes[name];
       callback(context);
     }
+  }
+
+  public visitContextBefore(context: Context): void {
+    this.triggerContextBefore(context);
+  }
+  public triggerContextBefore(context: Context): void {
+    this.triggerCallbacks(context, "ContextBefore");
+  }
+
+  public visitContextAfter(context: Context): void {
+    this.triggerContextAfter(context);
+  }
+  public triggerContextAfter(context: Context): void {
+    this.triggerCallbacks(context, "ContextAfter");
   }
 
   public visitNamespaceBefore(context: Context): void {


### PR DESCRIPTION
This PR adds two new visitor methods, `visitContextBefore` and `visitContextAfter` that are triggered at the start and end of a `context.accept()` call.

Note: I tried to make this a generic `visitStart`/`visitEnd` that applied to all visitors but they triggered repeatedly because of the downstream `accept()` calls. It wasn't obvious that fixing it would be simple so I opted for this constrained case that covers basic needs.