### PR TITLE
Miscellaneous rule fixes

### DIFF
--- a/src/rules/unique_object_names.ts
+++ b/src/rules/unique_object_names.ts
@@ -35,6 +35,9 @@ export class UniqueObjectNames extends AbstractVisitor {
   visitEnum(context: Context): void {
     this.check(context, context.enum!.name.value, context.enum!.name);
   }
+  visitAlias(context: Context): void {
+    this.check(context, context.alias!.name.value, context.alias!.name);
+  }
   private check(context: Context, name: string, node: Node): void {
     if (this.typeNames.has(name)) {
       context.reportError(validationError(node, `duplicate object "${name}"`));

--- a/src/rules/unique_parameter_names.ts
+++ b/src/rules/unique_parameter_names.ts
@@ -21,12 +21,13 @@ export class UniqueParameterNames extends AbstractVisitor {
   private parentName: string = "";
   private paramNames: Set<string> = new Set<string>();
 
-  visitFunction(context: Context): void {
-    this.parentName = "func " + context.operation!.name.value;
+  visitFunctionBefore(context: Context): void {
+    this.parentName = `func "${context.operation!.name.value}"`;
     this.paramNames = new Set<string>();
   }
 
   visitOperationBefore(context: Context): void {
+    this.parentName = `operation "${context.operation!.name.value}"`;
     this.parentName = context.operation!.name.value;
     this.paramNames = new Set<string>();
   }
@@ -38,7 +39,7 @@ export class UniqueParameterNames extends AbstractVisitor {
       context.reportError(
         validationError(
           param.name,
-          `duplicate parameter "${paramName}" in operation "${this.parentName}"`
+          `duplicate parameter "${paramName}" in ${this.parentName}`
         )
       );
     } else {

--- a/src/rules/valid_annotation_arguments.ts
+++ b/src/rules/valid_annotation_arguments.ts
@@ -135,7 +135,7 @@ export class ValidAnnotationArguments extends AbstractVisitor {
                 value,
                 `invalid value "${value.getValue()}" in annotation "${
                   annotation.name.value
-                }": expected a string`
+                }": expected a integer`
               )
             );
             return;

--- a/src/rules/valid_annotation_locations.ts
+++ b/src/rules/valid_annotation_locations.ts
@@ -103,6 +103,7 @@ export class ValidAnnotationLocations extends AbstractVisitor {
       return;
     }
 
+    dirRequiresLoop:
     for (let req of dir.requires) {
       let found = false;
       for (let loc of req.locations) {
@@ -110,14 +111,14 @@ export class ValidAnnotationLocations extends AbstractVisitor {
           case "SELF":
             if (findAnnotation(req.directive.value, annotations)) {
               found = true;
-              break;
+              break dirRequiresLoop;
             }
           case "NAMESPACE":
             if (
               findAnnotation(req.directive.value, context.namespace.annotations)
             ) {
               found = true;
-              break;
+              break dirRequiresLoop;
             }
           case "INTERFACE":
             if (
@@ -128,7 +129,7 @@ export class ValidAnnotationLocations extends AbstractVisitor {
               )
             ) {
               found = true;
-              break;
+              break dirRequiresLoop;
             }
           case "PARAMETER":
             if (
@@ -139,7 +140,7 @@ export class ValidAnnotationLocations extends AbstractVisitor {
               )
             ) {
               found = true;
-              break;
+              break dirRequiresLoop;
             }
           case "TYPE":
             if (
@@ -147,7 +148,7 @@ export class ValidAnnotationLocations extends AbstractVisitor {
               findAnnotation(req.directive.value, context.type!.annotations)
             ) {
               found = true;
-              break;
+              break dirRequiresLoop;
             }
           case "FIELD":
             if (
@@ -155,7 +156,7 @@ export class ValidAnnotationLocations extends AbstractVisitor {
               findAnnotation(req.directive.value, context.field!.annotations)
             ) {
               found = true;
-              break;
+              break dirRequiresLoop;
             }
           case "ENUM":
             if (
@@ -163,7 +164,7 @@ export class ValidAnnotationLocations extends AbstractVisitor {
               findAnnotation(req.directive.value, context.enum!.annotations)
             ) {
               found = true;
-              break;
+              break dirRequiresLoop;
             }
           case "ENUM_VALUE":
             if (
@@ -174,7 +175,7 @@ export class ValidAnnotationLocations extends AbstractVisitor {
               )
             ) {
               found = true;
-              break;
+              break dirRequiresLoop;
             }
           case "UNION":
             if (
@@ -182,7 +183,7 @@ export class ValidAnnotationLocations extends AbstractVisitor {
               findAnnotation(req.directive.value, context.union!.annotations)
             ) {
               found = true;
-              break;
+              break dirRequiresLoop;
             }
           case "ALIAS":
             if (
@@ -190,7 +191,7 @@ export class ValidAnnotationLocations extends AbstractVisitor {
               findAnnotation(req.directive.value, context.alias!.annotations)
             ) {
               found = true;
-              break;
+              break dirRequiresLoop;
             }
         }
       }


### PR DESCRIPTION
This PR includes the following rule fixes:

* Ensure unique names including aliases.
* Improve parent name so non-unique parameter are obvious between between functions and operations.
* Fix error message for integer annotation argument validation.
* Fix break (out of loop) in valid annotation location check.