### PR TITLE
Using denoify to produce deno_dist for publishing on deno.land

### DIFF
--- a/deno_dist/README.md
+++ b/deno_dist/README.md
@@ -1,0 +1,83 @@
+# Apex Language Parser
+
+This library will parse `.apex` files into an AST. Refer to the docs [docs](https://docs.apexlang.io) for more information.
+
+## Installation
+
+```sh
+$ npm install @apexlang/core
+```
+
+## Usage (node v12+)
+
+```js
+import { parse, validate } from '@apexlang/core/index.js';
+import { CommonRules } from '@apexlang/core/rules/index.js';
+import { Context, Writer, AbstractVisitor } from '@apexlang/core/ast/index.js';
+
+const source = `
+namespace "mandelbrot"
+
+interface {
+  update(width: u32, height: u32, limit: u32): [u16]
+}`;
+
+const doc = parse(source, undefined, { noLocation: true });
+const errors = validate(doc, ...CommonRules);
+
+if (errors.length > 0) {
+  errors.map(e => console.log(e.message));
+} else {
+  const context = new Context({});
+  const writer = new Writer();
+  const visitor = new AbstractVisitor();
+  visitor.setCallback("Operation", "", function(context) {
+    const oper = context.operation;
+    if (oper == undefined || oper.name.value != "update") {
+      return;
+    }
+    console.log(oper);
+  });
+  doc.accept(context, visitor);
+}
+```
+
+## Usage (browser)
+
+```html
+<script type="module">
+import { parse, validate } from 'https://cdn.jsdelivr.net/npm/@apexlang/core/dist/index.js';
+import { CommonRules } from 'https://cdn.jsdelivr.net/npm/@apexlang/core/dist/rules/index.js';
+import { Context, Writer, AbstractVisitor } from 'https://cdn.jsdelivr.net/npm/@apexlang/core/dist/ast/index.js';
+
+const source = `
+namespace "mandelbrot"
+
+interface {
+  update(width: u32, height: u32, limit: u32): [u16]
+}`;
+
+const doc = parse(source, undefined, { noLocation: true });
+const errors = validate(doc, ...CommonRules);
+
+if (errors.length > 0) { 
+  errors.map(e => console.log(e.message));
+} else {
+  const context = new Context({});
+  const writer = new Writer();
+  const visitor = new AbstractVisitor();
+  visitor.setCallback("Operation", "", function(context) {
+    const oper = context.operation;
+    if (oper == undefined || oper.name.value != "update") {
+      return;
+    }
+    console.log(oper);
+  });
+  doc.accept(context, visitor);
+}
+</script>
+```
+
+## License
+
+[Apache License 2.0](https://choosealicense.com/licenses/apache-2.0/)

--- a/deno_dist/ast/definitions.ts
+++ b/deno_dist/ast/definitions.ts
@@ -1,0 +1,609 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { Kind } from "./kinds.ts";
+import { IntValue, StringValue, Value } from "./values.ts";
+import {
+  AbstractNode,
+  Name,
+  Annotation,
+  DirectiveRequire,
+  ImportName,
+} from "./nodes.ts";
+import { Named, Type } from "./types.ts";
+import { Location } from "./location.ts";
+import { Context, Visitor } from "./visitor.ts";
+
+export interface Definition {
+  getKind(): Kind;
+  isKind(kind: Kind): boolean;
+  getLoc(): Location | undefined;
+  imported: boolean;
+}
+
+export interface Annotated {
+  annotation(
+    name: string,
+    callback?: (annotation: Annotation) => void
+  ): Annotation | undefined;
+}
+
+export class NamespaceDefinition extends AbstractNode implements Annotated {
+  name: Name;
+  description?: StringValue;
+  annotations: Annotation[];
+
+  constructor(
+    loc: Location | undefined,
+    name: Name,
+    desc: StringValue | undefined,
+    annotations?: Annotation[]
+  ) {
+    super(Kind.NamespaceDefinition, loc);
+    this.description = desc;
+    this.name = name;
+    this.annotations = annotations || [];
+  }
+
+  annotation(
+    name: string,
+    callback?: (annotation: Annotation) => void
+  ): Annotation | undefined {
+    return getAnnotation(name, this.annotations, callback);
+  }
+
+  public accept(context: Context, visitor: Visitor): void {
+    visitor.visitNamespace(context);
+    visitAnnotations(context, visitor, this.annotations);
+  }
+}
+
+export class AliasDefinition extends AbstractNode implements Annotated {
+  name: Name;
+  description?: StringValue;
+  type: Type;
+  annotations: Annotation[];
+
+  constructor(
+    loc: Location | undefined,
+    name: Name,
+    description: StringValue | undefined,
+    type: Type,
+    annotations?: Annotation[]
+  ) {
+    super(Kind.AliasDefinition, loc);
+    this.name = name;
+    this.description = description;
+    this.type = type;
+    this.annotations = annotations || [];
+  }
+
+  annotation(
+    name: string,
+    callback?: (annotation: Annotation) => void
+  ): Annotation | undefined {
+    return getAnnotation(name, this.annotations, callback);
+  }
+
+  public accept(context: Context, visitor: Visitor): void {
+    visitor.visitAlias(context);
+    visitAnnotations(context, visitor, this.annotations);
+  }
+}
+
+export class ImportDefinition extends AbstractNode implements Annotated {
+  description?: StringValue;
+  all: boolean;
+  names: ImportName[];
+  from: StringValue;
+  annotations?: Annotation[];
+
+  constructor(
+    loc: Location | undefined,
+    description: StringValue | undefined,
+    all: boolean,
+    names: ImportName[],
+    from: StringValue,
+    annotations?: Annotation[]
+  ) {
+    super(Kind.ImportDefinition, loc);
+    this.description = description;
+    this.all = all;
+    this.names = names;
+    this.from = from;
+    this.annotations = annotations || [];
+  }
+
+  annotation(
+    name: string,
+    callback?: (annotation: Annotation) => void
+  ): Annotation | undefined {
+    return getAnnotation(name, this.annotations, callback);
+  }
+
+  public accept(context: Context, visitor: Visitor): void {
+    visitor.visitImport(context);
+    visitAnnotations(context, visitor, this.annotations);
+  }
+}
+
+export class TypeDefinition extends AbstractNode implements Annotated {
+  name: Name;
+  description?: StringValue;
+  interfaces: Named[];
+  annotations: Annotation[];
+  fields: FieldDefinition[];
+
+  constructor(
+    loc: Location | undefined,
+    name: Name,
+    desc: StringValue | undefined,
+    interfaces: Named[],
+    annotations: Annotation[],
+    fields: FieldDefinition[]
+  ) {
+    super(Kind.TypeDefinition, loc);
+    this.name = name;
+    this.description = desc;
+    this.interfaces = interfaces;
+    this.annotations = annotations;
+    this.fields = fields;
+  }
+
+  annotation(
+    name: string,
+    callback?: (annotation: Annotation) => void
+  ): Annotation | undefined {
+    return getAnnotation(name, this.annotations, callback);
+  }
+
+  public accept(context: Context, visitor: Visitor): void {
+    visitor.visitTypeBefore(context);
+    visitor.visitType(context);
+
+    context = context.clone({ fields: context.type!.fields });
+    visitor.visitTypeFieldsBefore(context);
+    context.fields!.map((field, index) => {
+      field.accept(context.clone({ field: field, fieldIndex: index }), visitor);
+    });
+    visitor.visitTypeFieldsAfter(context);
+
+    visitAnnotations(context, visitor, this.annotations);
+    visitor.visitTypeAfter(context);
+  }
+}
+
+export abstract class ValuedDefinition
+  extends AbstractNode
+  implements Annotated
+{
+  name: Name;
+  description?: StringValue;
+  type: Type;
+  default?: Value;
+  annotations: Annotation[];
+
+  constructor(
+    kind: Kind,
+    loc: Location | undefined,
+    name: Name,
+    desc: StringValue | undefined,
+    type: Type,
+    defaultVal: Value | undefined,
+    annotations: Annotation[]
+  ) {
+    super(kind, loc);
+    this.name = name;
+    this.description = desc;
+    this.type = type;
+    this.default = defaultVal;
+    this.annotations = annotations;
+  }
+
+  annotation(
+    name: string,
+    callback?: (annotation: Annotation) => void
+  ): Annotation | undefined {
+    return getAnnotation(name, this.annotations, callback);
+  }
+}
+
+export class FieldDefinition extends ValuedDefinition {
+  constructor(
+    loc: Location | undefined,
+    name: Name,
+    desc: StringValue | undefined,
+    type: Type,
+    defaultVal: Value | undefined,
+    annotations: Annotation[]
+  ) {
+    super(Kind.FieldDefinition, loc, name, desc, type, defaultVal, annotations);
+  }
+
+  public accept(context: Context, visitor: Visitor): void {
+    visitor.visitTypeField(context);
+    visitAnnotations(context, visitor, this.annotations);
+  }
+}
+
+export class InterfaceDefinition
+  extends AbstractNode
+  implements Definition, Annotated
+{
+  name: Name;
+  description?: StringValue;
+  operations: OperationDefinition[];
+  annotations: Annotation[];
+
+  constructor(
+    loc: Location | undefined,
+    name: Name,
+    desc?: StringValue,
+    op?: OperationDefinition[],
+    annotations?: Annotation[]
+  ) {
+    super(Kind.InterfaceDefinition, loc);
+    this.name = name;
+    this.description = desc;
+    this.operations = op || [];
+    this.annotations = annotations || [];
+  }
+
+  annotation(
+    name: string,
+    callback?: (annotation: Annotation) => void
+  ): Annotation | undefined {
+    return getAnnotation(name, this.annotations, callback);
+  }
+
+  public accept(context: Context, visitor: Visitor): void {
+    visitor.visitInterfaceBefore(context);
+    visitor.visitInterface(context);
+
+    context = context.clone({ operations: context.interface!.operations });
+    visitor.visitOperationsBefore(context);
+    context.operations!.map((operation) => {
+      operation.accept(context.clone({ operation: operation }), visitor);
+    });
+    visitor.visitOperationsAfter(context);
+
+    visitAnnotations(context, visitor, this.annotations);
+    visitor.visitInterfaceAfter(context);
+  }
+}
+
+export class OperationDefinition extends AbstractNode implements Annotated {
+  name: Name;
+  description: StringValue | undefined;
+  parameters: ParameterDefinition[];
+  type: Type;
+  annotations: Annotation[];
+  unary: boolean;
+
+  constructor(
+    loc: Location | undefined,
+    name: Name,
+    desc: StringValue | undefined,
+    type: Type,
+    annotations: Annotation[],
+    unary: boolean,
+    parameters: ParameterDefinition[]
+  ) {
+    super(Kind.OperationDefinition, loc);
+    this.name = name;
+    this.description = desc;
+    this.type = type;
+    this.annotations = annotations;
+    this.parameters = parameters;
+    this.unary = unary;
+  }
+
+  public isUnary(): boolean {
+    return this.unary && this.parameters && this.parameters.length == 1;
+  }
+
+  public unaryOp(): ParameterDefinition {
+    return this.parameters[0];
+  }
+
+  mapTypeToTranslation(
+    typeTranslation: (inp: Type) => string
+  ): Map<String, String> {
+    const mp = new Map<String, String>();
+    if (this.unary) {
+      mp.set(this.unaryOp().name.value, typeTranslation(this.unaryOp().type));
+    } else {
+      this.parameters.forEach((arg) => {
+        mp.set(arg.name.value, typeTranslation(arg.type));
+      });
+    }
+    return mp;
+  }
+
+  annotation(
+    name: string,
+    callback?: (annotation: Annotation) => void
+  ): Annotation | undefined {
+    return getAnnotation(name, this.annotations, callback);
+  }
+
+  public accept(context: Context, visitor: Visitor): void {
+    if (context.interface != undefined) {
+      visitor.visitOperationBefore(context);
+      visitor.visitOperation(context);
+    } else {
+      visitor.visitFunctionBefore(context);
+      visitor.visitFunction(context);
+    }
+
+    context = context.clone({ parameters: context.operation!.parameters });
+    visitor.visitParametersBefore(context);
+    context.parameters!.map((parameter, index) => {
+      parameter.accept(
+        context.clone({ parameter: parameter, parameterIndex: index }),
+        visitor
+      );
+    });
+    visitor.visitParametersAfter(context);
+
+    visitAnnotations(context, visitor, this.annotations);
+    if (context.interface) {
+      visitor.visitOperationAfter(context);
+    } else {
+      visitor.visitFunctionAfter(context);
+    }
+  }
+}
+
+export class ParameterDefinition extends ValuedDefinition {
+  constructor(
+    loc: Location | undefined,
+    name: Name,
+    desc: StringValue | undefined,
+    type: Type,
+    defaultVal: Value | undefined,
+    annotations: Annotation[]
+  ) {
+    super(
+      Kind.ParameterDefinition,
+      loc,
+      name,
+      desc,
+      type,
+      defaultVal,
+      annotations
+    );
+  }
+
+  public accept(context: Context, visitor: Visitor): void {
+    if (context.operation != undefined) {
+      visitor.visitParameter(context);
+    } else if (context.directive != undefined) {
+      visitor.visitDirectiveParameter(context);
+    }
+    visitAnnotations(context, visitor, this.annotations);
+  }
+}
+
+export class UnionDefinition
+  extends AbstractNode
+  implements Definition, Annotated
+{
+  name: Name;
+  description?: StringValue;
+  annotations: Annotation[];
+  types: Type[];
+
+  constructor(
+    loc: Location | undefined,
+    name: Name,
+    desc: StringValue | undefined,
+    annotations: Annotation[],
+    types: Type[]
+  ) {
+    super(Kind.UnionDefinition, loc);
+    this.name = name;
+    this.description = desc;
+    this.annotations = annotations;
+    this.types = types;
+  }
+
+  annotation(
+    name: string,
+    callback?: (annotation: Annotation) => void
+  ): Annotation | undefined {
+    return getAnnotation(name, this.annotations, callback);
+  }
+
+  public accept(context: Context, visitor: Visitor): void {
+    visitor.visitUnion(context);
+    visitAnnotations(context, visitor, this.annotations);
+  }
+}
+
+export class EnumDefinition
+  extends AbstractNode
+  implements Definition, Annotated
+{
+  name: Name;
+  description?: StringValue;
+  annotations: Annotation[];
+  values: EnumValueDefinition[];
+
+  constructor(
+    loc: Location | undefined,
+    name: Name,
+    desc: StringValue | undefined,
+    annotations: Annotation[],
+    values: EnumValueDefinition[]
+  ) {
+    super(Kind.EnumDefinition, loc);
+    this.name = name;
+    this.description = desc;
+    this.annotations = annotations;
+    this.values = values;
+  }
+
+  annotation(
+    name: string,
+    callback?: (annotation: Annotation) => void
+  ): Annotation | undefined {
+    return getAnnotation(name, this.annotations, callback);
+  }
+
+  public accept(context: Context, visitor: Visitor): void {
+    visitor.visitEnumBefore(context);
+    visitor.visitEnum(context);
+
+    context = context.clone({ enumValues: context.enum!.values });
+    visitor.visitEnumValuesBefore(context);
+    context.enumValues!.map((enumValue) => {
+      enumValue.accept(context.clone({ enumValue: enumValue }), visitor);
+    });
+    visitor.visitEnumValuesAfter(context);
+
+    visitAnnotations(context, visitor, this.annotations);
+    visitor.visitEnumAfter(context);
+  }
+}
+
+export class EnumValueDefinition
+  extends AbstractNode
+  implements Definition, Annotated
+{
+  name: Name;
+  description?: StringValue;
+  annotations: Annotation[];
+  index: IntValue;
+  display?: StringValue;
+
+  constructor(
+    loc: Location | undefined,
+    name: Name,
+    desc: StringValue | undefined,
+    index: IntValue,
+    display: StringValue | undefined,
+    annotations: Annotation[]
+  ) {
+    super(Kind.EnumValueDefinition, loc);
+    this.name = name;
+    this.index = index;
+    this.display = display;
+    this.description = desc;
+
+    this.annotations = annotations;
+  }
+
+  annotation(
+    name: string,
+    callback?: (annotation: Annotation) => void
+  ): Annotation | undefined {
+    return getAnnotation(name, this.annotations, callback);
+  }
+
+  public accept(context: Context, visitor: Visitor): void {
+    visitor.visitEnumValue(context);
+    visitAnnotations(context, visitor, this.annotations);
+  }
+}
+
+export class DirectiveDefinition extends AbstractNode implements Definition {
+  name: Name;
+  description?: StringValue;
+  parameters: ParameterDefinition[];
+  locations: Name[];
+  requires: DirectiveRequire[];
+
+  constructor(
+    loc: Location | undefined,
+    name: Name,
+    description: StringValue | undefined,
+    parameters: ParameterDefinition[],
+    locations: Name[],
+    requires?: DirectiveRequire[]
+  ) {
+    super(Kind.DirectiveDefinition, loc);
+    this.name = name;
+    this.description = description;
+    this.parameters = parameters;
+    this.locations = locations;
+    this.requires = requires || [];
+  }
+
+  public hasLocation(location: string): boolean {
+    for (let l of this.locations) {
+      if (l.value == location) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public accept(context: Context, visitor: Visitor): void {
+    visitor.visitDirectiveBefore(context);
+    visitor.visitDirective(context);
+
+    context = context.clone({ parameters: context.directive!.parameters });
+    visitor.visitDirectiveParametersBefore(context);
+    context.parameters!.map((parameter, index) => {
+      parameter.accept(
+        context.clone({ parameter: parameter, parameterIndex: index }),
+        visitor
+      );
+    });
+    visitor.visitDirectiveParametersAfter(context);
+
+    visitor.visitDirectiveAfter(context);
+  }
+}
+
+function visitAnnotations(
+  context: Context,
+  visitor: Visitor,
+  annotations?: Annotation[]
+) {
+  if (annotations == undefined) {
+    return;
+  }
+
+  visitor.visitAnnotationsBefore(context);
+  annotations!.map((annotation) => {
+    const c = context.clone({ annotation: annotation });
+    visitor.visitAnnotationBefore(c);
+    annotation.accept(c, visitor);
+    visitor.visitAnnotationAfter(c);
+  });
+  visitor.visitAnnotationsAfter(context);
+}
+
+function getAnnotation(
+  name: string,
+  annotations?: Annotation[],
+  callback?: (annotation: Annotation) => void
+): Annotation | undefined {
+  if (annotations == undefined) {
+    return undefined;
+  }
+  for (let a of annotations!) {
+    if (a.name.value === name) {
+      if (callback != undefined) {
+        callback(a);
+      }
+      return a;
+    }
+  }
+  return undefined;
+}

--- a/deno_dist/ast/document.ts
+++ b/deno_dist/ast/document.ts
@@ -1,0 +1,97 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { Kind } from "./kinds.ts";
+import { AbstractNode } from "./nodes.ts";
+import { Location } from "./location.ts";
+import { Definition } from "./definitions.ts";
+import { Context, Visitor } from "./visitor.ts";
+
+export class Document extends AbstractNode {
+  definitions: Definition[];
+
+  constructor(loc: Location | undefined, definitions: Definition[]) {
+    super(Kind.Document, loc);
+    this.definitions = definitions;
+  }
+
+  public accept(context: Context, visitor: Visitor): void {
+    context = new Context(context.config, this, context);
+    visitor.visitDocumentBefore(context);
+
+    context.namespaces.map((namespace) => {
+      namespace.accept(context.clone({ namespace: namespace }), visitor);
+    });
+
+    visitor.visitImportsBefore(context);
+    context.imports.map((importDef) => {
+      importDef.accept(context.clone({ importDef: importDef }), visitor);
+    });
+    visitor.visitImportsAfter(context);
+
+    visitor.visitDirectivesBefore(context);
+    context.directives.map((directive) => {
+      directive.accept(context.clone({ directive: directive }), visitor);
+    });
+    visitor.visitDirectivesAfter(context);
+
+    visitor.visitAliasesBefore(context);
+    context.aliases.map((alias) => {
+      alias.accept(context.clone({ alias: alias }), visitor);
+    });
+    visitor.visitAliasesAfter(context);
+
+    visitor.visitAllOperationsBefore(context);
+
+    visitor.visitFunctionsBefore(context);
+    context.functions.map((func) => {
+      func.accept(context.clone({ operation: func }), visitor);
+    });
+    visitor.visitFunctionsAfter(context);
+
+    visitor.visitInterfacesBefore(context);
+    context.interfaces.map((iface) => {
+      iface.accept(context.clone({ interface: iface }), visitor);
+    });
+    visitor.visitInterfacesAfter(context);
+
+    visitor.visitAllOperationsAfter(context);
+
+    visitor.visitTypesBefore(context);
+    context.types.map((type) => {
+      if (!type.annotation("novisit")) {
+        type.accept(context.clone({ type: type }), visitor);
+      }
+    });
+    visitor.visitTypesAfter(context);
+
+    visitor.visitUnionsBefore(context);
+    context.unions.map((union) => {
+      union.accept(context.clone({ union: union }), visitor);
+    });
+    visitor.visitUnionsAfter(context);
+
+    visitor.visitEnumsBefore(context);
+    context.enums.map((enumDef) => {
+      if (!enumDef.annotation("novisit")) {
+        enumDef.accept(context.clone({ enumDef: enumDef }), visitor);
+      }
+    });
+    visitor.visitEnumsAfter(context);
+
+    visitor.visitDocumentAfter(context);
+  }
+}

--- a/deno_dist/ast/index.ts
+++ b/deno_dist/ast/index.ts
@@ -1,0 +1,26 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export * from "./location.ts";
+export * from "./token.ts";
+export * from "./definitions.ts";
+export * from "./document.ts";
+export * from "./kinds.ts";
+export * from "./nodes.ts";
+export * from "./definitions.ts";
+export * from "./types.ts";
+export * from "./values.ts";
+export * from "./visitor.ts";

--- a/deno_dist/ast/kinds.ts
+++ b/deno_dist/ast/kinds.ts
@@ -1,0 +1,57 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export enum Kind {
+  // Nodes
+  Document = "Document",
+  Name = "Name",
+  Annotation = "Annotation",
+  Argument = "Argument",
+  DirectiveRequire = "DirectiveRequire",
+  ImportName = "ImportName",
+
+  // Values
+  IntValue = "IntValue",
+  FloatValue = "FloatValue",
+  StringValue = "StringValue",
+  BooleanValue = "BooleanValue",
+  EnumValue = "EnumValue",
+  ListValue = "ListValue",
+  MapValue = "MapValue",
+  ObjectValue = "ObjectValue",
+  ObjectField = "ObjectField",
+
+  // Types
+  Named = "Named",
+  ListType = "ListType",
+  MapType = "MapType",
+  Optional = "Optional",
+  Stream = "Stream",
+
+  // Definitions
+  NamespaceDefinition = "NamespaceDefinition",
+  ImportDefinition = "ImportDefinition",
+  AliasDefinition = "AliasDefinition",
+  InterfaceDefinition = "InterfaceDefinition",
+  OperationDefinition = "OperationDefinition",
+  ParameterDefinition = "ParameterDefinition",
+  TypeDefinition = "TypeDefinition",
+  FieldDefinition = "FieldDefinition",
+  UnionDefinition = "UnionDefinition",
+  EnumDefinition = "EnumDefinition",
+  EnumValueDefinition = "EnumValueDefinition",
+  DirectiveDefinition = "DirectiveDefinition",
+}

--- a/deno_dist/ast/location.ts
+++ b/deno_dist/ast/location.ts
@@ -1,0 +1,41 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export class Location {
+  start: number;
+  end: number;
+  source: Source;
+
+  constructor(start: number, end: number, source: Source) {
+    this.start = start || 0;
+    this.end = end || 0;
+    this.source = source || null;
+  }
+}
+
+export class Source {
+  body: string;
+  name: string;
+
+  constructor(name: string, body?: string) {
+    this.name = name;
+    this.body = body || "";
+  }
+
+  public setBody(str: string): void {
+    this.body = str;
+  }
+}

--- a/deno_dist/ast/mod.ts
+++ b/deno_dist/ast/mod.ts
@@ -1,0 +1,17 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export * from "./index.ts";

--- a/deno_dist/ast/nodes.ts
+++ b/deno_dist/ast/nodes.ts
@@ -1,0 +1,129 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { Context, Visitor } from "./visitor.ts";
+import { Location } from "./location.ts";
+import { Kind } from "./kinds.ts";
+import { Value } from "./values.ts";
+
+export interface Node {
+  getKind(): Kind;
+  isKind(kind: Kind): boolean;
+  getLoc(): Location | undefined;
+  accept(_context: Context, _visitor: Visitor): void;
+}
+
+export abstract class AbstractNode implements Node {
+  kind: Kind;
+  loc?: Location;
+  imported: boolean = false;
+
+  constructor(kind: Kind, loc: Location | undefined) {
+    this.kind = kind;
+    this.loc = loc;
+  }
+
+  public getKind(): Kind {
+    return this.kind;
+  }
+
+  public getLoc(): Location | undefined {
+    return this.loc;
+  }
+
+  public isKind(kind: Kind): boolean {
+    return this.kind === kind;
+  }
+
+  public accept(_context: Context, _visitor: Visitor): void {}
+}
+
+// Name implements Node
+export class Name extends AbstractNode {
+  value: string;
+
+  constructor(doc: Location | undefined, value: string) {
+    super(Kind.Name, doc);
+    this.value = value || "";
+  }
+}
+
+// Annotation implements Node
+export class Annotation extends AbstractNode {
+  name: Name;
+  arguments: Argument[];
+
+  constructor(loc: Location | undefined, name: Name, args?: Argument[]) {
+    super(Kind.Annotation, loc);
+    this.name = name;
+    this.arguments = args || [];
+  }
+
+  convert<T>(): T {
+    let obj: { [k: string]: any } = {};
+    this.arguments.map((arg) => {
+      obj[arg.name.value] = arg.value.getValue();
+    });
+    return obj as T;
+  }
+
+  public accept(context: Context, visitor: Visitor): void {
+    visitor.visitAnnotation(context);
+  }
+}
+
+// Argument implements Node
+export class Argument extends AbstractNode {
+  name: Name;
+  value: Value;
+
+  constructor(loc: Location | undefined, name: Name, value: Value) {
+    super(Kind.Argument, loc);
+    this.name = name || undefined;
+    this.value = value || undefined;
+  }
+}
+
+export class DirectiveRequire extends AbstractNode {
+  directive: Name;
+  locations: Name[];
+
+  constructor(doc: Location | undefined, directive: Name, locations: Name[]) {
+    super(Kind.DirectiveRequire, doc);
+    this.directive = directive;
+    this.locations = locations;
+  }
+
+  public hasLocation(location: string): boolean {
+    for (let l of this.locations) {
+      if (l.value == location) {
+        return true;
+      }
+    }
+    return false;
+  }
+}
+
+export class ImportName extends AbstractNode {
+  name: Name;
+  alias: Name | undefined;
+
+  constructor(doc: Location | undefined, name: Name, alias: Name | undefined) {
+    super(Kind.ImportName, doc);
+    this.name = name;
+    this.alias = alias;
+  }
+}

--- a/deno_dist/ast/token.ts
+++ b/deno_dist/ast/token.ts
@@ -1,0 +1,60 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export class Token {
+  /**
+   * The kind of Token.
+   */
+  kind: number;
+
+  /**
+   * The character offset at which this Node begins.
+   */
+  start: number;
+
+  /**
+   * The character offset at which this Node ends.
+   */
+  end: number;
+
+  /**
+   * For non-punctuation tokens, represents the interpreted value of the token.
+   */
+  value: string;
+
+  /**
+   * Tokens exist as nodes in a double-linked-list amongst all tokens
+   * including ignored tokens. <SOF> is always the first node and <EOF>
+   * the last.
+   */
+  prev: Token | null;
+  next: Token | null;
+
+  constructor(
+    kind: number,
+    start: number,
+    end: number,
+    prev: Token | null,
+    value?: string
+  ) {
+    this.kind = kind;
+    this.start = start;
+    this.end = end;
+    this.value = value || "";
+    this.prev = prev;
+    this.next = null;
+  }
+}

--- a/deno_dist/ast/types.ts
+++ b/deno_dist/ast/types.ts
@@ -1,0 +1,90 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { AbstractNode, Name, Node } from "./nodes.ts";
+import { Kind } from "./kinds.ts";
+import { Location } from "./location.ts";
+
+export interface Type extends Node {
+  string(): string;
+}
+
+export class Named extends AbstractNode implements Type {
+  name: Name;
+
+  constructor(loc: Location | undefined, name: Name) {
+    super(Kind.Named, loc);
+    this.name = name;
+  }
+
+  public string(): string {
+    return this.getKind();
+  }
+}
+
+export class ListType extends AbstractNode implements Type {
+  type: Type;
+
+  constructor(loc: Location | undefined, type: Type) {
+    super(Kind.ListType, loc);
+    this.type = type || null;
+  }
+
+  public string(): string {
+    return this.getKind();
+  }
+}
+
+export class MapType extends AbstractNode implements Type {
+  keyType: Type;
+  valueType: Type;
+
+  constructor(loc: Location | undefined, keyType: Type, valueType: Type) {
+    super(Kind.MapType, loc);
+    this.keyType = keyType || null;
+    this.valueType = valueType || null;
+  }
+
+  public string(): string {
+    return this.getKind();
+  }
+}
+
+export class Optional extends AbstractNode implements Type {
+  type: Type;
+
+  constructor(loc: Location | undefined, type: Type) {
+    super(Kind.Optional, loc);
+    this.type = type || null;
+  }
+
+  public string(): string {
+    return this.getKind();
+  }
+}
+
+export class Stream extends AbstractNode implements Type {
+  type: Type;
+
+  constructor(loc: Location | undefined, type: Type) {
+    super(Kind.Stream, loc);
+    this.type = type || null;
+  }
+
+  public string(): string {
+    return this.getKind();
+  }
+}

--- a/deno_dist/ast/values.ts
+++ b/deno_dist/ast/values.ts
@@ -1,0 +1,145 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { AbstractNode, Name, Node } from "./nodes.ts";
+import { Kind } from "./kinds.ts";
+import { Location } from "./location.ts";
+
+export interface Value extends Node {
+  getValue(): any;
+  getKind(): Kind;
+  isKind(kind: Kind): boolean;
+  getLoc(): Location | undefined;
+}
+
+export class IntValue extends AbstractNode implements Value {
+  value: number;
+
+  constructor(loc: Location | undefined, value: number) {
+    super(Kind.IntValue, loc);
+    this.value = value;
+  }
+
+  getValue(): any {
+    return this.value;
+  }
+}
+
+export class FloatValue extends AbstractNode implements Value {
+  value: number;
+
+  constructor(loc: Location | undefined, value: number) {
+    super(Kind.FloatValue, loc);
+    this.value = value;
+  }
+
+  getValue(): any {
+    return this.value;
+  }
+}
+
+export class StringValue extends AbstractNode implements Value {
+  value: string;
+
+  constructor(loc: Location | undefined, value: string) {
+    super(Kind.StringValue, loc);
+    this.value = value;
+  }
+
+  getValue(): string {
+    return this.value;
+  }
+}
+
+export class BooleanValue extends AbstractNode implements Value {
+  value: boolean;
+
+  constructor(loc: Location | undefined, value: boolean) {
+    super(Kind.BooleanValue, loc);
+    this.value = value;
+  }
+
+  getValue(): any {
+    return this.value;
+  }
+}
+
+export class EnumValue extends AbstractNode implements Value {
+  value: string;
+
+  constructor(loc: Location | undefined, value: string) {
+    super(Kind.EnumValue, loc);
+    this.value = value;
+  }
+
+  getValue(): any {
+    return this.value;
+  }
+}
+
+export class ListValue extends AbstractNode implements Value {
+  value: Value[];
+
+  constructor(loc: Location | undefined, value: Value[]) {
+    super(Kind.ListValue, loc);
+    this.value = value || null;
+  }
+
+  getValue(): any {
+    return this.value.map((item) => item.getValue());
+  }
+}
+
+export class ObjectValue extends AbstractNode implements Value {
+  fields: ObjectField[];
+
+  constructor(loc: Location | undefined, fields: ObjectField[]) {
+    super(Kind.ObjectValue, loc);
+    this.fields = fields || null;
+  }
+
+  get(key: string): Value | undefined {
+    for (let field of this.fields) {
+      if (field.name.value == key) {
+        return field.value;
+      }
+    }
+    return undefined;
+  }
+
+  getValue(): any {
+    let obj: { [k: string]: any } = {};
+    this.fields.map((field) => {
+      obj[field.name.value] = field.value.getValue();
+    });
+    return obj;
+  }
+}
+
+export class ObjectField extends AbstractNode implements Value {
+  name: Name;
+  value: Value;
+
+  constructor(loc: Location | undefined, name: Name, value: Value) {
+    super(Kind.ObjectField, loc);
+    this.name = name || null;
+    this.value = value || null;
+  }
+
+  getValue(): any {
+    return this.value.getValue();
+  }
+}

--- a/deno_dist/ast/visitor.ts
+++ b/deno_dist/ast/visitor.ts
@@ -1,0 +1,1147 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import {
+  NamespaceDefinition,
+  TypeDefinition,
+  InterfaceDefinition,
+  EnumDefinition,
+  UnionDefinition,
+  ParameterDefinition,
+  FieldDefinition,
+  OperationDefinition,
+  EnumValueDefinition,
+  DirectiveDefinition,
+  ImportDefinition,
+  AliasDefinition,
+} from "./definitions.ts";
+import { Document } from "./document.ts";
+import { Annotation, Name } from "./nodes.ts";
+import autoBind from "../auto-bind.ts";
+import { ApexError } from "../error/index.ts";
+import { Kind } from "./kinds.ts";
+
+export class Writer {
+  private code: string = "";
+
+  write(source: string) {
+    this.code += source;
+  }
+
+  string(): string {
+    return this.code;
+  }
+}
+
+export type ObjectMap<T = any> = { [key: string]: T };
+
+interface NamedParameters {
+  namespace?: NamespaceDefinition;
+  importDef?: ImportDefinition;
+  directive?: DirectiveDefinition;
+  alias?: AliasDefinition;
+  interface?: InterfaceDefinition;
+  type?: TypeDefinition;
+  operations?: OperationDefinition[];
+  operation?: OperationDefinition;
+  parameters?: ParameterDefinition[];
+  parameter?: ParameterDefinition;
+  parameterIndex?: number;
+  fields?: FieldDefinition[];
+  field?: FieldDefinition;
+  fieldIndex?: number;
+  enumDef?: EnumDefinition;
+  enumValues?: EnumValueDefinition[];
+  enumValue?: EnumValueDefinition;
+  union?: UnionDefinition;
+  annotation?: Annotation;
+}
+
+class ErrorHolder {
+  errors: ApexError[];
+
+  constructor() {
+    this.errors = new Array<ApexError>();
+  }
+
+  reportError(error: ApexError): void {
+    this.errors.push(error);
+  }
+}
+
+export class Context {
+  config: ObjectMap;
+  document?: Document;
+
+  // Top-level definitions
+  namespaces: NamespaceDefinition[];
+  imports: ImportDefinition[];
+  directives: DirectiveDefinition[];
+  directiveMap: Map<string, DirectiveDefinition>;
+  aliases: AliasDefinition[];
+  functions: OperationDefinition[];
+  interfaces: InterfaceDefinition[];
+  types: TypeDefinition[];
+  enums: EnumDefinition[];
+  unions: UnionDefinition[];
+  allTypes: Map<
+    string,
+    TypeDefinition | EnumDefinition | UnionDefinition | AliasDefinition
+  >;
+
+  // Drill-down definitions
+  namespace: NamespaceDefinition;
+  namespacePos: number = 9999;
+  import?: ImportDefinition;
+  directive?: DirectiveDefinition;
+  alias?: AliasDefinition;
+  interface?: InterfaceDefinition;
+  type?: TypeDefinition;
+  operations?: OperationDefinition[];
+  operation?: OperationDefinition;
+  parameters?: ParameterDefinition[];
+  parameter?: ParameterDefinition;
+  parameterIndex?: number;
+  fields?: FieldDefinition[];
+  field?: FieldDefinition;
+  fieldIndex?: number;
+  enum?: EnumDefinition;
+  enumValues?: EnumValueDefinition[];
+  enumValue?: EnumValueDefinition;
+  union?: UnionDefinition;
+
+  annotations?: Annotation[];
+  annotation?: Annotation;
+
+  private errors: ErrorHolder;
+
+  constructor(config: ObjectMap, document?: Document, other?: Context) {
+    this.config = config || {};
+
+    if (other != undefined) {
+      this.document = other.document;
+      this.namespace = other.namespace;
+      this.namespaces = other.namespaces;
+      this.imports = other.imports;
+      this.directives = other.directives;
+      this.directiveMap = other.directiveMap;
+      this.aliases = other.aliases;
+      this.functions = other.functions;
+      this.interfaces = other.interfaces;
+      this.enums = other.enums;
+      this.types = other.types;
+      this.unions = other.unions;
+      this.annotations = other.annotations;
+      this.annotation = other.annotation;
+      this.allTypes = other.allTypes;
+
+      this.errors = other.errors;
+    } else {
+      this.namespace = new NamespaceDefinition(
+        undefined,
+        new Name(undefined, ""),
+        undefined
+      );
+      this.namespaces = new Array<NamespaceDefinition>();
+      this.directives = new Array<DirectiveDefinition>();
+      this.directiveMap = new Map<string, DirectiveDefinition>();
+      this.imports = new Array<ImportDefinition>();
+      this.aliases = new Array<AliasDefinition>();
+      this.functions = new Array<OperationDefinition>();
+      this.interfaces = new Array<InterfaceDefinition>();
+      this.enums = new Array<EnumDefinition>();
+      this.types = new Array<TypeDefinition>();
+      this.unions = new Array<UnionDefinition>();
+      this.annotations = new Array<Annotation>();
+      this.allTypes = new Map<
+        string,
+        TypeDefinition | EnumDefinition | UnionDefinition | AliasDefinition
+      >();
+
+      this.errors = new ErrorHolder();
+    }
+
+    if (this.document == undefined && document != undefined) {
+      this.document = document!;
+      this.parseDocument();
+    }
+
+    autoBind(this);
+  }
+
+  clone({
+    namespace,
+    importDef,
+    directive,
+    alias,
+    interface: iface,
+    type,
+    operations,
+    operation,
+    parameters,
+    parameter,
+    parameterIndex,
+    fields,
+    field,
+    fieldIndex,
+    enumDef,
+    enumValues,
+    enumValue,
+    union,
+    annotation,
+  }: NamedParameters): Context {
+    var context = new Context(this.config, undefined, this);
+
+    context.namespace = namespace || this.namespace;
+    context.namespacePos = this.namespacePos;
+    context.import = importDef || this.import;
+    context.directive = directive || this.directive;
+    context.alias = alias || this.alias;
+    context.interface = iface || this.interface;
+    context.type = type || this.type;
+    context.operations = operations || this.operations;
+    context.operation = operation || this.operation;
+    context.parameters = parameters || this.parameters;
+    context.parameter = parameter || this.parameter;
+    context.parameterIndex = parameterIndex || this.parameterIndex;
+    context.fields = fields || this.fields;
+    context.field = field || this.field;
+    context.fieldIndex = fieldIndex || this.fieldIndex;
+    context.enum = enumDef || this.enum;
+    context.enumValues = enumValues || this.enumValues;
+    context.enumValue = enumValue || this.enumValue;
+    context.union = union || this.union;
+    context.annotation = annotation || this.annotation;
+
+    return context;
+  }
+
+  private parseDocument(): void {
+    this.document!.definitions.forEach((value, index) => {
+      switch (value.getKind()) {
+        case Kind.NamespaceDefinition:
+          const namespace = value as NamespaceDefinition;
+          this.namespaces.push(namespace);
+          this.namespace = namespace;
+          this.namespacePos = index;
+          break;
+        case Kind.DirectiveDefinition:
+          const directive = value as DirectiveDefinition;
+          this.directives.push(directive);
+          this.directiveMap.set(directive.name.value, directive);
+          break;
+        case Kind.ImportDefinition:
+          this.imports.push(value as ImportDefinition);
+          break;
+        case Kind.AliasDefinition:
+          const alias = value as AliasDefinition;
+          this.aliases.push(alias);
+          this.allTypes.set(alias.name.value, alias);
+          break;
+        case Kind.OperationDefinition:
+          const oper = value as OperationDefinition;
+          this.functions.push(oper);
+          break;
+        case Kind.InterfaceDefinition:
+          const iface = value as InterfaceDefinition;
+          this.interfaces.push(iface);
+          break;
+        case Kind.TypeDefinition:
+          const type = value as TypeDefinition;
+          this.types.push(type);
+          this.allTypes.set(type.name.value, type);
+          break;
+        case Kind.EnumDefinition:
+          const enumDef = value as EnumDefinition;
+          this.enums.push(enumDef);
+          this.allTypes.set(enumDef.name.value, enumDef);
+          break;
+        case Kind.UnionDefinition:
+          const union = value as UnionDefinition;
+          this.unions.push(union);
+          this.allTypes.set(union.name.value, union);
+          break;
+      }
+    });
+  }
+
+  reportError(error: ApexError): void {
+    this.errors.reportError(error);
+  }
+
+  getErrors(): ApexError[] {
+    return this.errors.errors;
+  }
+}
+
+export interface Visitor {
+  visitDocumentBefore(context: Context): void;
+  visitNamespace(context: Context): void;
+
+  visitImportsBefore(context: Context): void;
+  visitImport(context: Context): void;
+  visitImportsAfter(context: Context): void;
+
+  visitDirectivesBefore(context: Context): void;
+  visitDirectiveBefore(context: Context): void;
+  visitDirective(context: Context): void;
+  visitDirectiveParametersBefore(context: Context): void;
+  visitDirectiveParameter(context: Context): void;
+  visitDirectiveParametersAfter(context: Context): void;
+  visitDirectiveAfter(context: Context): void;
+  visitDirectivesAfter(context: Context): void;
+
+  visitAliasesBefore(context: Context): void;
+  visitAliasBefore(context: Context): void;
+  visitAlias(context: Context): void;
+  visitAliasAfter(context: Context): void;
+  visitAliasesAfter(context: Context): void;
+
+  visitAllOperationsBefore(context: Context): void;
+  visitFunctionsBefore(context: Context): void;
+  visitFunctionBefore(context: Context): void;
+  visitFunction(context: Context): void;
+  visitFunctionAfter(context: Context): void;
+  visitFunctionsAfter(context: Context): void;
+  visitInterfacesBefore(context: Context): void;
+  visitInterfaceBefore(context: Context): void;
+  visitInterface(context: Context): void;
+  visitOperationsBefore(context: Context): void;
+  visitOperationBefore(context: Context): void;
+  visitOperation(context: Context): void;
+  visitParametersBefore(context: Context): void;
+  visitParameter(context: Context): void;
+  visitParametersAfter(context: Context): void;
+  visitOperationAfter(context: Context): void;
+  visitOperationsAfter(context: Context): void;
+  visitInterfaceAfter(context: Context): void;
+  visitInterfacesAfter(context: Context): void;
+  visitAllOperationsAfter(context: Context): void;
+
+  visitTypesBefore(context: Context): void;
+  visitTypeBefore(context: Context): void;
+  visitType(context: Context): void;
+  visitTypeFieldsBefore(context: Context): void;
+  visitTypeField(context: Context): void;
+  visitTypeFieldsAfter(context: Context): void;
+  visitTypeAfter(context: Context): void;
+  visitTypesAfter(context: Context): void;
+
+  visitEnumsBefore(context: Context): void;
+  visitEnumBefore(context: Context): void;
+  visitEnum(context: Context): void;
+  visitEnumValuesBefore(context: Context): void;
+  visitEnumValue(context: Context): void;
+  visitEnumValuesAfter(context: Context): void;
+  visitEnumAfter(context: Context): void;
+  visitEnumsAfter(context: Context): void;
+
+  visitUnionsBefore(context: Context): void;
+  visitUnion(context: Context): void;
+  visitUnionsAfter(context: Context): void;
+
+  visitAnnotationsBefore(context: Context): void;
+  visitAnnotationBefore(context: Context): void;
+  visitAnnotation(context: Context): void;
+  visitAnnotationArgumentsBefore(context: Context): void;
+  visitAnnotationArgument(context: Context): void;
+  visitAnnotationArgumentsAfter(context: Context): void;
+  visitAnnotationAfter(context: Context): void;
+  visitAnnotationsAfter(context: Context): void;
+
+  visitDocumentAfter(_context: Context): void;
+}
+
+export type Callbacks = Map<string, Map<string, VisitorCallback>>;
+export type VisitorCallback = (_context: Context) => void;
+
+export abstract class AbstractVisitor implements Visitor {
+  callbacks: Callbacks = new Map<string, Map<string, VisitorCallback>>();
+
+  setCallback(phase: string, purpose: string, callback: VisitorCallback): void {
+    var purposes = this.callbacks.get(phase);
+    if (purposes == undefined) {
+      purposes = new Map<string, VisitorCallback>();
+      this.callbacks.set(phase, purposes);
+    }
+    purposes.set(purpose, callback);
+  }
+
+  triggerCallbacks(context: Context, phase: string): void {
+    var purposes = this.callbacks.get(phase);
+    if (purposes == undefined) {
+      return;
+    }
+    purposes.forEach((callback) => {
+      callback(context);
+    });
+  }
+
+  public visitDocumentBefore(context: Context): void {
+    this.triggerDocumentBefore(context);
+  }
+  public triggerDocumentBefore(context: Context): void {
+    this.triggerCallbacks(context, "DocumentBefore");
+  }
+  public visitNamespace(context: Context): void {
+    this.triggerNamespace(context);
+  }
+  public triggerNamespace(context: Context): void {
+    this.triggerCallbacks(context, "Namespace");
+  }
+  public visitImportsBefore(context: Context): void {
+    this.triggerImportsBefore(context);
+  }
+  public triggerImportsBefore(context: Context): void {
+    this.triggerCallbacks(context, "ImportsBefore");
+  }
+  public visitImport(context: Context): void {
+    this.triggerImport(context);
+  }
+  public triggerImport(context: Context): void {
+    this.triggerCallbacks(context, "Import");
+  }
+  public visitImportsAfter(context: Context): void {
+    this.triggerImportsAfter(context);
+  }
+  public triggerImportsAfter(context: Context): void {
+    this.triggerCallbacks(context, "ImportsAfter");
+  }
+
+  public visitDirectivesBefore(context: Context): void {
+    this.triggerDirectivesBefore(context);
+  }
+  public triggerDirectivesBefore(context: Context): void {
+    this.triggerCallbacks(context, "DirectivesBefore");
+  }
+  public visitDirectiveBefore(context: Context): void {
+    this.triggerDirectiveBefore(context);
+  }
+  public triggerDirectiveBefore(context: Context): void {
+    this.triggerCallbacks(context, "DirectiveBefore");
+  }
+  public visitDirective(context: Context): void {
+    this.triggerDirective(context);
+  }
+  public triggerDirective(context: Context): void {
+    this.triggerCallbacks(context, "Directive");
+  }
+
+  public visitDirectiveParametersBefore(context: Context): void {
+    this.triggerDirectiveParametersBefore(context);
+  }
+  public triggerDirectiveParametersBefore(context: Context): void {
+    this.triggerCallbacks(context, "DirectiveParametersBefore");
+  }
+  public visitDirectiveParameter(context: Context): void {
+    this.triggerDirectiveParameter(context);
+  }
+  public triggerDirectiveParameter(context: Context): void {
+    this.triggerCallbacks(context, "DirectiveParameter");
+  }
+  public visitDirectiveParametersAfter(context: Context): void {
+    this.triggerDirectiveParametersAfter(context);
+  }
+  public triggerDirectiveParametersAfter(context: Context): void {
+    this.triggerCallbacks(context, "DirectiveParametersAfter");
+  }
+
+  public visitDirectiveAfter(context: Context): void {
+    this.triggerDirectiveBefore(context);
+  }
+  public triggerDirectiveAfter(context: Context): void {
+    this.triggerCallbacks(context, "DirectiveAfter");
+  }
+  public visitDirectivesAfter(context: Context): void {
+    this.triggerDirectivesAfter(context);
+  }
+  public triggerDirectivesAfter(context: Context): void {
+    this.triggerCallbacks(context, "DirectivesAfter");
+  }
+
+  public visitAliasesBefore(context: Context): void {
+    this.triggerAliasesBefore(context);
+  }
+  public triggerAliasesBefore(context: Context): void {
+    this.triggerCallbacks(context, "AliasesBefore");
+  }
+  public visitAliasBefore(context: Context): void {
+    this.triggerAliasBefore(context);
+  }
+  public triggerAliasBefore(context: Context): void {
+    this.triggerCallbacks(context, "AliasBefore");
+  }
+  public visitAlias(context: Context): void {
+    this.triggerAlias(context);
+  }
+  public triggerAlias(context: Context): void {
+    this.triggerCallbacks(context, "Alias");
+  }
+  public visitAliasAfter(context: Context): void {
+    this.triggerAliasBefore(context);
+  }
+  public triggerAliasAfter(context: Context): void {
+    this.triggerCallbacks(context, "AliasAfter");
+  }
+  public visitAliasesAfter(context: Context): void {
+    this.triggerAliasesAfter(context);
+  }
+  public triggerAliasesAfter(context: Context): void {
+    this.triggerCallbacks(context, "AliasesAfter");
+  }
+
+  public visitAllOperationsBefore(context: Context): void {
+    this.triggerAllOperationsBefore(context);
+  }
+  public triggerAllOperationsBefore(context: Context): void {
+    this.triggerCallbacks(context, "AllOperationsBefore");
+  }
+  public visitFunctionsBefore(context: Context): void {
+    this.triggerFunctionsBefore(context);
+  }
+  public triggerFunctionsBefore(context: Context): void {
+    this.triggerCallbacks(context, "FunctionsBefore");
+  }
+  public visitFunctionBefore(context: Context): void {
+    this.triggerFunctionBefore(context);
+  }
+  public triggerFunctionBefore(context: Context): void {
+    this.triggerCallbacks(context, "FunctionBefore");
+  }
+  public visitFunction(context: Context): void {
+    this.triggerFunction(context);
+  }
+  public triggerFunction(context: Context): void {
+    this.triggerCallbacks(context, "Function");
+  }
+  public visitFunctionAfter(context: Context): void {
+    this.triggerFunctionAfter(context);
+  }
+  public triggerFunctionAfter(context: Context): void {
+    this.triggerCallbacks(context, "FunctionAfter");
+  }
+  public visitFunctionsAfter(context: Context): void {
+    this.triggerFunctionsAfter(context);
+  }
+  public triggerFunctionsAfter(context: Context): void {
+    this.triggerCallbacks(context, "FunctionsAfter");
+  }
+  public visitInterfacesBefore(context: Context): void {
+    this.triggerInterfacesBefore(context);
+  }
+  public triggerInterfacesBefore(context: Context): void {
+    this.triggerCallbacks(context, "InterfacesBefore");
+  }
+  public visitInterfaceBefore(context: Context): void {
+    this.triggerInterfaceBefore(context);
+  }
+  public triggerInterfaceBefore(context: Context): void {
+    this.triggerCallbacks(context, "InterfaceBefore");
+  }
+  public visitInterface(context: Context): void {
+    this.triggerInterface(context);
+  }
+  public triggerInterface(context: Context): void {
+    this.triggerCallbacks(context, "Interface");
+  }
+  public visitOperationsBefore(context: Context): void {
+    this.triggerOperationsBefore(context);
+  }
+  public triggerOperationsBefore(context: Context): void {
+    this.triggerCallbacks(context, "OperationsBefore");
+  }
+  public visitOperationBefore(context: Context): void {
+    this.triggerOperationBefore(context);
+  }
+  public triggerOperationBefore(context: Context): void {
+    this.triggerCallbacks(context, "OperationBefore");
+  }
+  public visitOperation(context: Context): void {
+    this.triggerOperation(context);
+  }
+  public triggerOperation(context: Context): void {
+    this.triggerCallbacks(context, "Operation");
+  }
+  public visitParametersBefore(context: Context): void {
+    this.triggerParametersBefore(context);
+  }
+  public triggerParametersBefore(context: Context): void {
+    this.triggerCallbacks(context, "ParametersBefore");
+  }
+  public visitParameter(context: Context): void {
+    this.triggerParameter(context);
+  }
+  public triggerParameter(context: Context): void {
+    this.triggerCallbacks(context, "Parameter");
+  }
+  public visitParametersAfter(context: Context): void {
+    this.triggerParametersAfter(context);
+  }
+  public triggerParametersAfter(context: Context): void {
+    this.triggerCallbacks(context, "ParametersAfter");
+  }
+  public visitOperationAfter(context: Context): void {
+    this.triggerOperationAfter(context);
+  }
+  public triggerOperationAfter(context: Context): void {
+    this.triggerCallbacks(context, "OperationAfter");
+  }
+  public visitOperationsAfter(context: Context): void {
+    this.triggerOperationsAfter(context);
+  }
+  public triggerOperationsAfter(context: Context): void {
+    this.triggerCallbacks(context, "OperationsAfter");
+  }
+  public visitInterfaceAfter(context: Context): void {
+    this.triggerInterfaceAfter(context);
+  }
+  public triggerInterfaceAfter(context: Context): void {
+    this.triggerCallbacks(context, "InterfaceAfter");
+  }
+  public visitInterfacesAfter(context: Context): void {
+    this.triggerInterfacesAfter(context);
+  }
+  public triggerInterfacesAfter(context: Context): void {
+    this.triggerCallbacks(context, "InterfacesAfter");
+  }
+  public visitAllOperationsAfter(context: Context): void {
+    this.triggerAllOperationsAfter(context);
+  }
+  public triggerAllOperationsAfter(context: Context): void {
+    this.triggerCallbacks(context, "AllOperationsAfter");
+  }
+
+  public visitTypesBefore(context: Context): void {
+    this.triggerTypesBefore(context);
+  }
+  public triggerTypesBefore(context: Context): void {
+    this.triggerCallbacks(context, "TypesBefore");
+  }
+  public visitTypeBefore(context: Context): void {
+    this.triggerTypeBefore(context);
+  }
+  public triggerTypeBefore(context: Context): void {
+    this.triggerCallbacks(context, "TypeBefore");
+  }
+  public visitType(context: Context): void {
+    this.triggerType(context);
+  }
+  public triggerType(context: Context): void {
+    this.triggerCallbacks(context, "Type");
+  }
+  public visitTypeFieldsBefore(context: Context): void {
+    this.triggerTypeFieldsBefore(context);
+  }
+  public triggerTypeFieldsBefore(context: Context): void {
+    this.triggerCallbacks(context, "TypeFieldsBefore");
+  }
+  public visitTypeField(context: Context): void {
+    this.triggerTypeField(context);
+  }
+  public triggerTypeField(context: Context): void {
+    this.triggerCallbacks(context, "TypeField");
+  }
+  public visitTypeFieldsAfter(context: Context): void {
+    this.triggerTypeFieldsAfter(context);
+  }
+  public triggerTypeFieldsAfter(context: Context): void {
+    this.triggerCallbacks(context, "TypeFieldsAfter");
+  }
+  public visitTypeAfter(context: Context): void {
+    this.triggerTypeAfter(context);
+  }
+  public triggerTypeAfter(context: Context): void {
+    this.triggerCallbacks(context, "TypeAfter");
+  }
+  public visitTypesAfter(context: Context): void {
+    this.triggerTypesAfter(context);
+  }
+  public triggerTypesAfter(context: Context): void {
+    this.triggerCallbacks(context, "TypesAfter");
+  }
+
+  public visitEnumsBefore(context: Context): void {
+    this.triggerEnumsBefore(context);
+  }
+  public triggerEnumsBefore(context: Context): void {
+    this.triggerCallbacks(context, "EnumsBefore");
+  }
+  public visitEnumBefore(context: Context): void {
+    this.triggerEnumsBefore(context);
+  }
+  public triggerEnumBefore(context: Context): void {
+    this.triggerCallbacks(context, "EnumBefore");
+  }
+  public visitEnum(context: Context): void {
+    this.triggerEnum(context);
+  }
+  public triggerEnum(context: Context): void {
+    this.triggerCallbacks(context, "Enum");
+  }
+  public visitEnumValuesBefore(context: Context): void {
+    this.triggerEnumValuesBefore(context);
+  }
+  public triggerEnumValuesBefore(context: Context): void {
+    this.triggerCallbacks(context, "EnumValuesBefore");
+  }
+  public visitEnumValue(context: Context): void {
+    this.triggerEnumValue(context);
+  }
+  public triggerEnumValue(context: Context): void {
+    this.triggerCallbacks(context, "EnumValue");
+  }
+  public visitEnumValuesAfter(context: Context): void {
+    this.triggerEnumValuesAfter(context);
+  }
+  public triggerEnumValuesAfter(context: Context): void {
+    this.triggerCallbacks(context, "EnumValuesAfter");
+  }
+  public visitEnumAfter(context: Context): void {
+    this.triggerEnumsAfter(context);
+  }
+  public triggerEnumAfter(context: Context): void {
+    this.triggerCallbacks(context, "EnumAfter");
+  }
+  public visitEnumsAfter(context: Context): void {
+    this.triggerEnumsAfter(context);
+  }
+  public triggerEnumsAfter(context: Context): void {
+    this.triggerCallbacks(context, "EnumsAfter");
+  }
+
+  public visitUnionsBefore(context: Context): void {
+    this.triggerUnionsBefore(context);
+  }
+  public triggerUnionsBefore(context: Context): void {
+    this.triggerCallbacks(context, "UnionsBefore");
+  }
+  public visitUnion(context: Context): void {
+    this.triggerCallbacks(context, "Union");
+  }
+  public triggerUnion(context: Context): void {
+    this.triggerCallbacks(context, "Union");
+  }
+  public visitUnionsAfter(context: Context): void {
+    this.triggerUnionsAfter(context);
+  }
+  public triggerUnionsAfter(context: Context): void {
+    this.triggerCallbacks(context, "UnionsAfter");
+  }
+
+  public visitAnnotationsBefore(context: Context): void {
+    this.triggerAnnotationsBefore(context);
+  }
+  public triggerAnnotationsBefore(context: Context): void {
+    this.triggerCallbacks(context, "AnnotationsBefore");
+  }
+  public visitAnnotationBefore(context: Context): void {
+    this.triggerAnnotationBefore(context);
+  }
+  public triggerAnnotationBefore(context: Context): void {
+    this.triggerCallbacks(context, "AnnotationBefore");
+  }
+  public visitAnnotation(context: Context): void {
+    this.triggerAnnotation(context);
+  }
+  public triggerAnnotation(context: Context): void {
+    this.triggerCallbacks(context, "Annotation");
+  }
+
+  public visitAnnotationArgumentsBefore(context: Context): void {
+    this.triggerAnnotationArgumentsBefore(context);
+  }
+  public triggerAnnotationArgumentsBefore(context: Context): void {
+    this.triggerCallbacks(context, "AnnotationArgumentsBefore");
+  }
+  public visitAnnotationArgument(context: Context): void {
+    this.triggerAnnotationArgument(context);
+  }
+  public triggerAnnotationArgument(context: Context): void {
+    this.triggerCallbacks(context, "AnnotationArgument");
+  }
+  public visitAnnotationArgumentsAfter(context: Context): void {
+    this.triggerAnnotationArgumentsAfter(context);
+  }
+  public triggerAnnotationArgumentsAfter(context: Context): void {
+    this.triggerCallbacks(context, "AnnotationArgumentsAfter");
+  }
+  public visitAnnotationAfter(context: Context): void {
+    this.triggerAnnotationAfter(context);
+  }
+  public triggerAnnotationAfter(context: Context): void {
+    this.triggerCallbacks(context, "AnnotationAfter");
+  }
+  public visitAnnotationsAfter(context: Context): void {
+    this.triggerAnnotationsAfter(context);
+  }
+  public triggerAnnotationsAfter(context: Context): void {
+    this.triggerCallbacks(context, "AnnotationsAfter");
+  }
+
+  public visitDocumentAfter(context: Context): void {
+    this.triggerDocumentAfter(context);
+  }
+  public triggerDocumentAfter(context: Context): void {
+    this.triggerCallbacks(context, "DocumentAfter");
+  }
+}
+
+export class BaseVisitor extends AbstractVisitor {
+  writer: Writer;
+
+  constructor(writer: Writer) {
+    super();
+    this.writer = writer;
+  }
+
+  protected write(code: string): void {
+    this.writer.write(code);
+  }
+}
+
+export class MultiVisitor extends AbstractVisitor {
+  private visitors: Visitor[];
+
+  constructor(...visitors: Visitor[]) {
+    super();
+    this.visitors = new Array<Visitor>();
+    this.visitors.push(...visitors);
+  }
+
+  addVisitors(...visitors: Visitor[]): void {
+    this.visitors.push(...visitors);
+  }
+
+  public visitDocumentBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitDocumentBefore(context);
+    });
+  }
+  public visitNamespace(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitNamespace(context);
+    });
+  }
+  public visitImportsBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitImportsBefore(context);
+    });
+  }
+  public visitImport(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitImport(context);
+    });
+  }
+  public visitImportsAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitImportsAfter(context);
+    });
+  }
+
+  public visitDirectivesBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitDirectivesBefore(context);
+    });
+  }
+  public visitDirectiveBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitDirectiveBefore(context);
+    });
+  }
+  public visitDirective(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitDirective(context);
+    });
+  }
+  public visitDirectiveParametersBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitDirectiveParametersBefore(context);
+    });
+  }
+  public visitDirectiveParameter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitDirectiveParameter(context);
+    });
+  }
+  public visitDirectiveParametersAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitDirectiveParametersAfter(context);
+    });
+  }
+  public visitDirectiveAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitDirectiveAfter(context);
+    });
+  }
+  public visitDirectivesAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitDirectivesAfter(context);
+    });
+  }
+
+  public visitAliasesBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitAliasesBefore(context);
+    });
+  }
+  public visitAliasBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitAliasBefore(context);
+    });
+  }
+  public visitAlias(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitAlias(context);
+    });
+  }
+  public visitAliasAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitAliasAfter(context);
+    });
+  }
+  public visitAliasesAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitAliasesAfter(context);
+    });
+  }
+
+  public visitAllOperationsBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitAllOperationsBefore(context);
+    });
+  }
+  public visitInterfacesBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitInterfacesBefore(context);
+    });
+  }
+  public visitInterfaceBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitInterfaceBefore(context);
+    });
+  }
+  public visitInterface(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitInterface(context);
+    });
+  }
+  public visitFunctionsBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitFunctionsBefore(context);
+    });
+  }
+  public visitFunctionBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitFunctionBefore(context);
+    });
+  }
+  public visitFunction(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitFunction(context);
+    });
+  }
+  public visitFunctionAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitFunctionAfter(context);
+    });
+  }
+  public visitFunctionsAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitFunctionsAfter(context);
+    });
+  }
+  public visitOperationsBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitOperationsBefore(context);
+    });
+  }
+  public visitOperationBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitOperationBefore(context);
+    });
+  }
+  public visitOperation(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitOperation(context);
+    });
+  }
+  public visitParametersBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitParametersBefore(context);
+    });
+  }
+  public visitParameter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitParameter(context);
+    });
+  }
+  public visitParametersAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitParametersAfter(context);
+    });
+  }
+  public visitOperationAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitOperationAfter(context);
+    });
+  }
+  public visitOperationsAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitOperationsAfter(context);
+    });
+  }
+  public visitInterfaceAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitInterfaceAfter(context);
+    });
+  }
+  public visitInterfacesAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitInterfacesAfter(context);
+    });
+  }
+  public visitAllOperationsAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitAllOperationsAfter(context);
+    });
+  }
+
+  public visitTypesBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitTypesBefore(context);
+    });
+  }
+  public visitTypeBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitTypeBefore(context);
+    });
+  }
+  public visitType(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitType(context);
+    });
+  }
+  public visitTypeFieldsBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitTypeFieldsBefore(context);
+    });
+  }
+  public visitTypeField(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitTypeField(context);
+    });
+  }
+  public visitTypeFieldsAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitTypeFieldsAfter(context);
+    });
+  }
+  public visitTypeAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitTypeAfter(context);
+    });
+  }
+  public visitTypesAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitTypesAfter(context);
+    });
+  }
+
+  public visitEnumsBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitEnumsAfter(context);
+    });
+  }
+  public visitEnum(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitEnum(context);
+    });
+  }
+  public visitEnumValuesBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitEnumValuesBefore(context);
+    });
+  }
+  public visitEnumValue(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitEnumValue(context);
+    });
+  }
+  public visitEnumValuesAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitEnumValuesAfter(context);
+    });
+  }
+  public visitEnumsAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitEnumsAfter(context);
+    });
+  }
+
+  public visitUnionsBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitUnionsBefore(context);
+    });
+  }
+  public visitUnion(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitUnion(context);
+    });
+  }
+
+  public visitUnionsAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitUnionsAfter(context);
+    });
+  }
+
+  public visitAnnotationsBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitAnnotationsBefore(context);
+    });
+  }
+  public visitAnnotation(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitAnnotation(context);
+    });
+  }
+  public visitAnnotationArgumentsBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitAnnotationArgumentsBefore(context);
+    });
+  }
+  public visitAnnotationArgument(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitAnnotationArgument(context);
+    });
+  }
+  public visitAnnotationArgumentsAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitAnnotationArgumentsAfter(context);
+    });
+  }
+  public visitAnnotationsAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitAnnotationsAfter(context);
+    });
+  }
+
+  public visitDocumentAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitDocumentAfter(context);
+    });
+  }
+}

--- a/deno_dist/auto-bind.ts
+++ b/deno_dist/auto-bind.ts
@@ -1,0 +1,94 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+const CONSTRUCTOR = "constructor";
+
+interface IPrototype {
+  [key: string]: Function;
+}
+
+interface IReactExcludeMethods {
+  [key: string]: boolean;
+}
+
+const REACT_EXCLUDE_METHODS: IReactExcludeMethods = {
+  render: true,
+  setState: true,
+  forceUpdate: true,
+  UNSAFE_componentWillUpdate: true,
+  UNSAFE_componentWillMount: true,
+  getChildContext: true,
+  componentWillMount: true,
+  componentDidMount: true,
+  componentWillReceiveProps: true,
+  shouldComponentUpdate: true,
+  componentWillUpdate: true,
+  componentDidUpdate: true,
+  componentWillUnmount: true,
+  componentDidCatch: true,
+  getSnapshotBeforeUpdate: true,
+};
+
+export default function autobind(instance: unknown, proto?: unknown): void {
+  if (!proto) {
+    try {
+      proto = Object.getPrototypeOf(instance);
+    } catch (error) {
+      throw new Error(`Cannot get prototype of ${instance}`);
+    }
+  }
+  const properties = Object.getOwnPropertyNames(proto);
+  properties.forEach((name: string) => bind(name, instance, proto));
+}
+
+function bind(name: string, instance: unknown, proto?: unknown): void {
+  if (!isPrototype<IPrototype>(proto)) {
+    return;
+  }
+  if (!isPrototype<IPrototype>(instance)) {
+    return;
+  }
+  if (name === CONSTRUCTOR) {
+    return;
+  }
+  const descriptor = Object.getOwnPropertyDescriptor(proto, name);
+  if (!descriptor) {
+    return;
+  }
+  if (descriptor.get || descriptor.set) {
+    Object.defineProperty(proto, name, {
+      ...descriptor,
+      get: descriptor.get ? descriptor.get.bind(instance) : void 0,
+      set: descriptor.set ? descriptor.set.bind(instance) : void 0,
+    });
+    return;
+  }
+  if (isFunction(descriptor.value) && !isExcluded(name)) {
+    instance[name] = proto[name].bind(instance);
+  }
+}
+
+function isExcluded(key: string): boolean {
+  return REACT_EXCLUDE_METHODS[key] === true;
+}
+
+function isFunction(item: unknown): item is Function {
+  return typeof item === "function";
+}
+
+export function isPrototype<T extends object>(value: unknown): value is T {
+  return typeof value === "object";
+}

--- a/deno_dist/blockstring.ts
+++ b/deno_dist/blockstring.ts
@@ -1,0 +1,116 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// @flow strict
+
+/**
+ * Produces the value of a block string from its parsed raw value, similar to
+ * CoffeeScript's block string, Python's docstring trim or Ruby's strip_heredoc.
+ *
+ * This implements the Apex spec's BlockStringValue() static algorithm.
+ *
+ * @internal
+ */
+export function dedentBlockStringValue(rawString: string): string {
+  // Expand a block string's raw value into independent lines.
+  const lines = rawString.split(/\r\n|[\n\r]/g);
+
+  // Remove common indentation from all lines but first.
+  const commonIndent = getBlockStringIndentation(lines);
+
+  if (commonIndent !== 0) {
+    for (let i = 1; i < lines.length; i++) {
+      lines[i] = lines[i].slice(commonIndent);
+    }
+  }
+
+  // Remove leading and trailing blank lines.
+  while (lines.length > 0 && isBlank(lines[0])) {
+    lines.shift();
+  }
+  while (lines.length > 0 && isBlank(lines[lines.length - 1])) {
+    lines.pop();
+  }
+
+  // Return a string of the lines joined with U+000A.
+  return lines.join("\n");
+}
+/**
+ * @internal
+ */
+export function getBlockStringIndentation(lines: Array<string>): number {
+  let commonIndent = null;
+
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i];
+    const indent = leadingWhitespace(line);
+    if (indent === line.length) {
+      continue; // skip empty lines
+    }
+
+    if (commonIndent === null || indent < commonIndent) {
+      commonIndent = indent;
+      if (commonIndent === 0) {
+        break;
+      }
+    }
+  }
+
+  return commonIndent === null ? 0 : commonIndent;
+}
+
+function leadingWhitespace(str: string) {
+  let i = 0;
+  while (i < str.length && (str[i] === " " || str[i] === "\t")) {
+    i++;
+  }
+  return i;
+}
+
+function isBlank(str: string) {
+  return leadingWhitespace(str) === str.length;
+}
+
+/**
+ * Print a block string in the indented block form by adding a leading and
+ * trailing blank line. However, if a block string starts with whitespace and is
+ * a single-line, adding a leading blank line would strip that whitespace.
+ *
+ * @internal
+ */
+export function printBlockString(
+  value: string,
+  indentation: string = "",
+  preferMultipleLines: boolean = false
+): string {
+  const isSingleLine = value.indexOf("\n") === -1;
+  const hasLeadingSpace = value[0] === " " || value[0] === "\t";
+  const hasTrailingQuote = value[value.length - 1] === '"';
+  const printAsMultipleLines =
+    !isSingleLine || hasTrailingQuote || preferMultipleLines;
+
+  let result = "";
+  // Format a multi-line block quote to account for leading space.
+  if (printAsMultipleLines && !(isSingleLine && hasLeadingSpace)) {
+    result += "\n" + indentation;
+  }
+  result += indentation ? value.replace(/\n/g, "\n" + indentation) : value;
+  if (printAsMultipleLines) {
+    result += "\n";
+  }
+
+  return '"""' + result.replace(/"""/g, '\\"""') + '"""';
+}

--- a/deno_dist/error/error.ts
+++ b/deno_dist/error/error.ts
@@ -1,0 +1,82 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { Node, Source } from "../ast/index.ts";
+
+export class ApexError extends Error {
+  nodes: Array<Node> | Node | undefined;
+  source: Source | undefined;
+  positions: Array<number> | undefined;
+  path: Array<string | number> | undefined;
+
+  constructor(
+    message: string,
+    nodes: Array<Node> | Node | undefined,
+    source: Source | undefined,
+    positions: Array<number> | undefined,
+    path: Array<string | number> | undefined
+  ) {
+    super(message);
+    this.nodes = nodes;
+    this.source = source;
+    this.positions = positions;
+    this.path = path;
+  }
+}
+
+export function syntaxError(
+  source: Source,
+  position: number,
+  description: string
+): ApexError {
+  return new ApexError(
+    `Syntax Error: ${description}`,
+    undefined,
+    source,
+    [position],
+    undefined
+  );
+}
+
+export function importError(node: Node, description: string): ApexError {
+  const loc = node.getLoc();
+  var source: Source | undefined;
+  if (loc != undefined) {
+    source = loc.source;
+  }
+  return new ApexError(
+    `Import Error: ${description}`,
+    node,
+    source,
+    undefined,
+    undefined
+  );
+}
+
+export function validationError(node: Node, description: string): ApexError {
+  const loc = node.getLoc();
+  var source: Source | undefined;
+  if (loc != undefined) {
+    source = loc.source;
+  }
+  return new ApexError(
+    `Validation Error: ${description}`,
+    node,
+    source,
+    undefined,
+    undefined
+  );
+}

--- a/deno_dist/error/index.ts
+++ b/deno_dist/error/index.ts
@@ -1,0 +1,17 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export * from "./error.ts";

--- a/deno_dist/error/mod.ts
+++ b/deno_dist/error/mod.ts
@@ -1,0 +1,17 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export * from "./index.ts";

--- a/deno_dist/index.ts
+++ b/deno_dist/index.ts
@@ -1,0 +1,27 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export * from "./parser.ts";
+export * from "./validator.ts";
+
+// Expose `Apex.ast` for the browser
+export * as ast from "./ast/index.ts";
+
+// Expose `Apex.error` for the browser
+export * as error from "./error/index.ts";
+
+// Expose `Apex.rules` for the browser
+export * as rules from "./rules/index.ts";

--- a/deno_dist/lexer.ts
+++ b/deno_dist/lexer.ts
@@ -1,0 +1,775 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// @flow strict
+
+//import { syntaxError } from '../error/syntaxError';
+
+import { Token, Source } from "./ast/index.ts";
+import { dedentBlockStringValue } from "./blockstring.ts";
+import { TokenDescription, TokenKind } from "./token_kind.ts";
+import { syntaxError } from "./error/index.ts";
+/**
+ * Given a Source object, creates a Lexer for that source.
+ * A Lexer is a stateful stream generator in that every time
+ * it is advanced, it returns the next token in the Source. Assuming the
+ * source lexes, the final Token emitted by the lexer will be of kind
+ * EOF, after which the lexer will repeatedly return the same EOF token
+ * whenever called.
+ */
+export class Lexer {
+  source: Source;
+
+  /**
+   * The previously focused non-ignored token.
+   */
+  lastToken: Token;
+
+  /**
+   * The currently focused non-ignored token.
+   */
+  token: Token;
+
+  /**
+   * The (1-indexed) line containing the current token.
+   */
+  line: number;
+
+  /**
+   * The character offset at which the current line begins.
+   */
+  lineStart: number;
+
+  constructor(source: Source) {
+    const startOfFileToken = new Token(TokenKind.SOF, 0, 0, null);
+
+    this.source = source;
+    this.lastToken = startOfFileToken;
+    this.token = startOfFileToken;
+    this.line = 1;
+    this.lineStart = 0;
+  }
+
+  /**
+   * Advances the token stream to the next non-ignored token.
+   */
+  advance(): Token {
+    this.lastToken = this.token;
+    const token = (this.token = this.lookahead());
+    return token;
+  }
+
+  /**
+   * Looks ahead and returns the next non-ignored token, but does not change
+   * the state of Lexer.
+   */
+  lookahead(): Token {
+    let token = this.token;
+    if (token.kind !== TokenKind.EOF) {
+      do {
+        // Note: next is only mutable during parsing, so we cast to allow this.
+        token = token.next ?? (token.next = readToken(this, token));
+      } while (token.kind === TokenKind.COMMENT);
+    }
+    return token;
+  }
+}
+
+/**
+ * @internal
+ */
+export function isPunctuatorTokenKind(kind: TokenKind): boolean {
+  return (
+    kind === TokenKind.BANG ||
+    kind === TokenKind.DOLLAR ||
+    kind === TokenKind.AMP ||
+    kind === TokenKind.PAREN_L ||
+    kind === TokenKind.PAREN_R ||
+    kind === TokenKind.SPREAD ||
+    kind === TokenKind.COLON ||
+    kind === TokenKind.EQUALS ||
+    kind === TokenKind.STAR ||
+    kind === TokenKind.AT ||
+    kind === TokenKind.BRACKET_L ||
+    kind === TokenKind.BRACKET_R ||
+    kind === TokenKind.BRACE_L ||
+    kind === TokenKind.PIPE ||
+    kind === TokenKind.BRACE_R
+  );
+}
+
+function printCharCode(code: number) {
+  return (
+    // NaN/undefined represents access beyond the end of the file.
+    isNaN(code)
+      ? TokenKind.EOF
+      : // Trust JSON for ASCII.
+      code < 0x007f
+      ? JSON.stringify(String.fromCharCode(code))
+      : // Otherwise print the escaped form.
+        `"\\u${("00" + code.toString(16).toUpperCase()).slice(-4)}"`
+  );
+}
+
+/**
+ * Gets the next token from the source starting at the given position.
+ *
+ * This skips over whitespace until it finds the next lexable token, then lexes
+ * punctuators immediately or calls the appropriate helper function for more
+ * complicated tokens.
+ */
+function readToken(lexer: Lexer, prev: Token): Token {
+  const source = lexer.source;
+  const body = source.body;
+  const bodyLength = body.length;
+
+  const pos = positionAfterWhitespace(body, prev.end, lexer);
+  const line = lexer.line;
+  const col = 1 + pos - lexer.lineStart;
+
+  if (pos >= bodyLength) {
+    return new Token(TokenKind.EOF, bodyLength, bodyLength, prev);
+  }
+
+  const code = body.charCodeAt(pos);
+
+  // SourceCharacter
+  switch (code) {
+    // !
+    case 33:
+      return new Token(TokenKind.BANG, pos, pos + 1, prev);
+    // #
+    case 35:
+      return readComment(source, pos, line, col, prev);
+    // $
+    case 36:
+      return new Token(TokenKind.DOLLAR, pos, pos + 1, prev);
+    // &
+    case 38:
+      return new Token(TokenKind.AMP, pos, pos + 1, prev);
+    // (
+    case 40:
+      return new Token(TokenKind.PAREN_L, pos, pos + 1, prev);
+    // )
+    case 41:
+      return new Token(TokenKind.PAREN_R, pos, pos + 1, prev);
+    // *
+    case 42:
+      return new Token(TokenKind.STAR, pos, pos + 1, prev);
+    // .
+    case 46:
+      if (body.charCodeAt(pos + 1) === 46 && body.charCodeAt(pos + 2) === 46) {
+        return new Token(TokenKind.SPREAD, pos, pos + 3, prev);
+      }
+      break;
+    // :
+    case 58:
+      return new Token(TokenKind.COLON, pos, pos + 1, prev);
+    // =
+    case 61:
+      return new Token(TokenKind.EQUALS, pos, pos + 1, prev);
+    // ?
+    case 63:
+      return new Token(TokenKind.QUESTION, pos, pos + 1, prev);
+    // @
+    case 64:
+      return new Token(TokenKind.AT, pos, pos + 1, prev);
+    // [
+    case 91:
+      return new Token(TokenKind.BRACKET_L, pos, pos + 1, prev);
+    // ]
+    case 93:
+      return new Token(TokenKind.BRACKET_R, pos, pos + 1, prev);
+    // {
+    case 123:
+      return new Token(TokenKind.BRACE_L, pos, pos + 1, prev);
+    // |
+    case 124:
+      return new Token(TokenKind.PIPE, pos, pos + 1, prev);
+    // }
+    case 125:
+      return new Token(TokenKind.BRACE_R, pos, pos + 1, prev);
+    // A-Z _ a-z
+    case 65:
+    case 66:
+    case 67:
+    case 68:
+    case 69:
+    case 70:
+    case 71:
+    case 72:
+    case 73:
+    case 74:
+    case 75:
+    case 76:
+    case 77:
+    case 78:
+    case 79:
+    case 80:
+    case 81:
+    case 82:
+    case 83:
+    case 84:
+    case 85:
+    case 86:
+    case 87:
+    case 88:
+    case 89:
+    case 90:
+    case 95:
+    case 97:
+    case 98:
+    case 99:
+    case 100:
+    case 101:
+    case 102:
+    case 103:
+    case 104:
+    case 105:
+    case 106:
+    case 107:
+    case 108:
+    case 109:
+    case 110:
+    case 111:
+    case 112:
+    case 113:
+    case 114:
+    case 115:
+    case 116:
+    case 117:
+    case 118:
+    case 119:
+    case 120:
+    case 121:
+    case 122:
+      return readName(source, pos, line, col, prev);
+    // - 0-9
+    case 45:
+    case 48:
+    case 49:
+    case 50:
+    case 51:
+    case 52:
+    case 53:
+    case 54:
+    case 55:
+    case 56:
+    case 57:
+      return readNumber(source, pos, code, line, col, prev);
+    // "
+    case 34:
+      if (body.charCodeAt(pos + 1) === 34 && body.charCodeAt(pos + 2) === 34) {
+        return readBlockString(source, pos, line, col, prev, lexer);
+      }
+      return readString(source, pos, line, col, prev);
+  }
+
+  throw syntaxError(source, pos, "unexpected char");
+}
+
+/**
+ * Report a message that an unexpected character was encountered.
+ */
+function unexpectedCharacterMessage(code: number) {
+  if (code < 0x0020 && code !== 0x0009 && code !== 0x000a && code !== 0x000d) {
+    return `Cannot contain the invalid character ${printCharCode(code)}.`;
+  }
+
+  if (code === 39) {
+    // '
+    return "Unexpected single quote character ('), did you mean to use a double quote (\")?";
+  }
+
+  return `Cannot parse the unexpected character ${printCharCode(code)}.`;
+}
+
+/**
+ * Reads from body starting at startPosition until it finds a non-whitespace
+ * character, then returns the position of that character for lexing.
+ */
+function positionAfterWhitespace(
+  body: string,
+  startPosition: number,
+  lexer: Lexer
+): number {
+  const bodyLength = body.length;
+  let position = startPosition;
+  while (position < bodyLength) {
+    const code = body.charCodeAt(position);
+    // tab | space | comma | BOM
+    if (code === 9 || code === 32 || code === 44 || code === 0xfeff) {
+      ++position;
+    } else if (code === 10) {
+      // new line
+      ++position;
+      ++lexer.line;
+      lexer.lineStart = position;
+    } else if (code === 13) {
+      // carriage return
+      if (body.charCodeAt(position + 1) === 10) {
+        position += 2;
+      } else {
+        ++position;
+      }
+      ++lexer.line;
+      lexer.lineStart = position;
+    } else {
+      break;
+    }
+  }
+  return position;
+}
+
+/**
+ * Reads a comment token from the source file.
+ *
+ * #[\u0009\u0020-\uFFFF]*
+ */
+function readComment(
+  source: Source,
+  start: number,
+  line: number,
+  col: number,
+  prev: Token
+): Token {
+  const body = source.body;
+  let code;
+  let position = start;
+
+  do {
+    code = body.charCodeAt(++position);
+  } while (
+    !isNaN(code) &&
+    // SourceCharacter but not LineTerminator
+    (code > 0x001f || code === 0x0009)
+  );
+
+  return new Token(
+    TokenKind.COMMENT,
+    start,
+    position,
+    prev,
+    body.slice(start + 1, position)
+  );
+}
+
+/**
+ * Reads a number token from the source file, either a float
+ * or an int depending on whether a decimal point appears.
+ *
+ * Int:   -?(0|[1-9][0-9]*)
+ * Float: -?(0|[1-9][0-9]*)(\.[0-9]+)?((E|e)(+|-)?[0-9]+)?
+ */
+function readNumber(
+  source: Source,
+  start: number,
+  firstCode: number,
+  line: number,
+  col: number,
+  prev: Token
+): Token {
+  const body = source.body;
+  let code = firstCode;
+  let position = start;
+  let isFloat = false;
+
+  if (code === 45) {
+    // -
+    code = body.charCodeAt(++position);
+  }
+
+  if (code === 48) {
+    // 0
+    code = body.charCodeAt(++position);
+    if (code >= 48 && code <= 57) {
+      /*
+      throw syntaxError(
+        source,
+        position,
+        `Invalid number, unexpected digit after 0: ${printCharCode(code)}.`,
+      );*/
+    }
+  } else {
+    position = readDigits(source, position, code);
+    code = body.charCodeAt(position);
+  }
+
+  if (code === 46) {
+    // .
+    isFloat = true;
+
+    code = body.charCodeAt(++position);
+    position = readDigits(source, position, code);
+    code = body.charCodeAt(position);
+  }
+
+  if (code === 69 || code === 101) {
+    // E e
+    isFloat = true;
+
+    code = body.charCodeAt(++position);
+    if (code === 43 || code === 45) {
+      // + -
+      code = body.charCodeAt(++position);
+    }
+    position = readDigits(source, position, code);
+    code = body.charCodeAt(position);
+  }
+
+  // Numbers cannot be followed by . or NameStart
+  if (code === 46 || isNameStart(code)) {
+    /*
+    throw syntaxError(
+      source,
+      position,
+      `Invalid number, expected digit but got: ${printCharCode(code)}.`,
+    );*/
+  }
+
+  return new Token(
+    isFloat ? TokenKind.FLOAT : TokenKind.INT,
+    start,
+    position,
+    prev,
+    body.slice(start, position)
+  );
+}
+
+/**
+ * Returns the new position in the source after reading digits.
+ */
+function readDigits(source: Source, start: number, firstCode: number): number {
+  const body = source.body;
+  let position = start;
+  let code = firstCode;
+  if (code >= 48 && code <= 57) {
+    // 0 - 9
+    do {
+      code = body.charCodeAt(++position);
+    } while (code >= 48 && code <= 57); // 0 - 9
+    return position;
+  }
+  return -1; // Remove this
+  // TODO
+  /*
+  throw syntaxError(
+    source,
+    position,
+    `Invalid number, expected digit but got: ${printCharCode(code)}.`,
+  );*/
+}
+
+/**
+ * Reads a string token from the source file.
+ *
+ * "([^"\\\u000A\u000D]|(\\(u[0-9a-fA-F]{4}|["\\/bfnrt])))*"
+ */
+function readString(
+  source: Source,
+  start: number,
+  line: number,
+  col: number,
+  prev: Token
+): Token {
+  const body = source.body;
+  let position = start + 1;
+  let chunkStart = position;
+  let code = 0;
+  let value = "";
+
+  while (
+    position < body.length &&
+    !isNaN((code = body.charCodeAt(position))) &&
+    // not LineTerminator
+    code !== 0x000a &&
+    code !== 0x000d
+  ) {
+    // Closing Quote (")
+    if (code === 34) {
+      value += body.slice(chunkStart, position);
+      return new Token(TokenKind.STRING, start, position + 1, prev, value);
+    }
+
+    // SourceCharacter
+    if (code < 0x0020 && code !== 0x0009) {
+      // TODO
+      /*
+      throw syntaxError(
+        source,
+        position,
+        `Invalid character within String: ${printCharCode(code)}.`,
+      );
+      */
+    }
+
+    ++position;
+    if (code === 92) {
+      // \
+      value += body.slice(chunkStart, position - 1);
+      code = body.charCodeAt(position);
+      switch (code) {
+        case 34:
+          value += '"';
+          break;
+        case 47:
+          value += "/";
+          break;
+        case 92:
+          value += "\\";
+          break;
+        case 98:
+          value += "\b";
+          break;
+        case 102:
+          value += "\f";
+          break;
+        case 110:
+          value += "\n";
+          break;
+        case 114:
+          value += "\r";
+          break;
+        case 116:
+          value += "\t";
+          break;
+        case 117: {
+          // uXXXX
+          const charCode = uniCharCode(
+            body.charCodeAt(position + 1),
+            body.charCodeAt(position + 2),
+            body.charCodeAt(position + 3),
+            body.charCodeAt(position + 4)
+          );
+          if (charCode < 0) {
+            const invalidSequence = body.slice(position + 1, position + 5);
+            throw syntaxError(source, position, "invalid sequence");
+            /*throw syntaxError(
+              source,
+              position,
+              `Invalid character escape sequence: \\u${invalidSequence}.`,
+            );*/
+          }
+          value += String.fromCharCode(charCode);
+          position += 4;
+          break;
+        }
+        default:
+          throw syntaxError(
+            source,
+            position,
+            "Invalid character escape sequence"
+          );
+        /*throw syntaxError(
+            source,
+            position,
+            `Invalid character escape sequence: \\${String.fromCharCode(
+              code,
+            )}.`,
+          );*/
+      }
+      ++position;
+      chunkStart = position;
+    }
+  }
+  throw syntaxError(source, position, "Unterminated string.");
+  //throw syntaxError(source, position, 'Unterminated string.');
+}
+
+/**
+ * Reads a block string token from the source file.
+ *
+ * """("?"?(\\"""|\\(?!=""")|[^"\\]))*"""
+ */
+function readBlockString(
+  source: Source,
+  start: number,
+  line: number,
+  col: number,
+  prev: Token,
+  lexer: Lexer
+): Token {
+  const body = source.body;
+  let position = start + 3;
+  let chunkStart = position;
+  let code = 0;
+  let rawValue = "";
+
+  while (position < body.length && !isNaN((code = body.charCodeAt(position)))) {
+    // Closing Triple-Quote (""")
+    if (
+      code === 34 &&
+      body.charCodeAt(position + 1) === 34 &&
+      body.charCodeAt(position + 2) === 34
+    ) {
+      rawValue += body.slice(chunkStart, position);
+      return new Token(
+        TokenKind.BLOCK_STRING,
+        start,
+        position + 3,
+        prev,
+        dedentBlockStringValue(rawValue)
+      );
+    }
+
+    // SourceCharacter
+    if (
+      code < 0x0020 &&
+      code !== 0x0009 &&
+      code !== 0x000a &&
+      code !== 0x000d
+    ) {
+      throw syntaxError(
+        source,
+        position,
+        "Invalid character within String: ${printCharCode(code)}"
+      );
+      /*
+      throw syntaxError(
+        source,
+        position,
+        `Invalid character within String: ${printCharCode(code)}.`,
+      );
+      */
+    }
+
+    if (code === 10) {
+      // new line
+      ++position;
+      ++lexer.line;
+      lexer.lineStart = position;
+    } else if (code === 13) {
+      // carriage return
+      if (body.charCodeAt(position + 1) === 10) {
+        position += 2;
+      } else {
+        ++position;
+      }
+      ++lexer.line;
+      lexer.lineStart = position;
+    } else if (
+      // Escape Triple-Quote (\""")
+      code === 92 &&
+      body.charCodeAt(position + 1) === 34 &&
+      body.charCodeAt(position + 2) === 34 &&
+      body.charCodeAt(position + 3) === 34
+    ) {
+      rawValue += body.slice(chunkStart, position) + '"""';
+      position += 4;
+      chunkStart = position;
+    } else {
+      ++position;
+    }
+  }
+
+  throw syntaxError(source, position, "Unterminated string.");
+  //throw syntaxError(source, position, 'Unterminated string.');
+}
+
+/**
+ * Converts four hexadecimal chars to the integer that the
+ * string represents. For example, uniCharCode('0','0','0','f')
+ * will return 15, and uniCharCode('0','0','f','f') returns 255.
+ *
+ * Returns a negative number on error, if a char was invalid.
+ *
+ * This is implemented by noting that char2hex() returns -1 on error,
+ * which means the result of ORing the char2hex() will also be negative.
+ */
+function uniCharCode(a: number, b: number, c: number, d: number) {
+  return (
+    (char2hex(a) << 12) | (char2hex(b) << 8) | (char2hex(c) << 4) | char2hex(d)
+  );
+}
+
+/**
+ * Converts a hex character to its integer value.
+ * '0' becomes 0, '9' becomes 9
+ * 'A' becomes 10, 'F' becomes 15
+ * 'a' becomes 10, 'f' becomes 15
+ *
+ * Returns -1 on error.
+ */
+function char2hex(a: number) {
+  return a >= 48 && a <= 57
+    ? a - 48 // 0-9
+    : a >= 65 && a <= 70
+    ? a - 55 // A-F
+    : a >= 97 && a <= 102
+    ? a - 87 // a-f
+    : -1;
+}
+
+/**
+ * Reads an alphanumeric + underscore name from the source.
+ *
+ * [_A-Za-z][_0-9A-Za-z]*
+ */
+function readName(
+  source: Source,
+  start: number,
+  line: number,
+  col: number,
+  prev: Token
+): Token {
+  const body = source.body;
+  const bodyLength = body.length;
+  let position = start + 1;
+  let code = 0;
+  while (
+    position !== bodyLength &&
+    !isNaN((code = body.charCodeAt(position))) &&
+    (code === 95 || // _
+      (code >= 48 && code <= 57) || // 0-9
+      (code >= 65 && code <= 90) || // A-Z
+      (code >= 97 && code <= 122)) // a-z
+  ) {
+    ++position;
+  }
+  return new Token(
+    TokenKind.NAME,
+    start,
+    position,
+    prev,
+    body.slice(start, position)
+  );
+}
+
+// _ A-Z a-z
+function isNameStart(code: number): boolean {
+  return (
+    code === 95 || (code >= 65 && code <= 90) || (code >= 97 && code <= 122)
+  );
+}
+
+/**
+ * A helper function to describe a token as a string for debugging
+ */
+export function getTokenDesc(token: Token): string {
+  const desc = getTokenKindDesc(token.kind);
+  if (token.value == "") {
+    return desc;
+  }
+
+  return `kind: ${desc} \"${token.value}\"`;
+}
+
+/**
+ * A helper function to describe a token kind as a string for debugging
+ */
+export function getTokenKindDesc(kind: number): string {
+  return TokenDescription.get(kind) || "";
+}

--- a/deno_dist/mod.ts
+++ b/deno_dist/mod.ts
@@ -1,0 +1,17 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export * from "./index.ts";

--- a/deno_dist/model/index.ts
+++ b/deno_dist/model/index.ts
@@ -1,0 +1,19 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export * from "./model.ts";
+export * from "./kinds.ts";
+export * from "./visitor.ts";

--- a/deno_dist/model/kinds.ts
+++ b/deno_dist/model/kinds.ts
@@ -1,0 +1,40 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export enum Kind {
+  // Models
+  Namespace = "Namespace",
+  Import = "Import",
+  Alias = "Alias",
+  Interface = "Interface",
+  Operation = "Operation",
+  Parameter = "Parameter",
+  Type = "Type",
+  Field = "Field",
+  Union = "Union",
+  Enum = "Enum",
+  EnumValue = "EnumValue",
+  Directive = "Directive",
+  Require = "Require",
+  Annotation = "Annotation",
+  Argument = "Argument",
+  Void = "Void",
+  Primitive = "Primitive",
+  List = "List",
+  Map = "Map",
+  Optional = "Optional",
+  Stream = "Stream",
+}

--- a/deno_dist/model/mod.ts
+++ b/deno_dist/model/mod.ts
@@ -1,0 +1,17 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export * from "./index.ts";

--- a/deno_dist/model/model.ts
+++ b/deno_dist/model/model.ts
@@ -1,0 +1,693 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import {
+  NamespaceDefinition,
+  Annotation as AnnotationDef,
+  Argument as ArgumentDef,
+  AliasDefinition,
+  TypeDefinition,
+  FieldDefinition,
+  Value,
+  ValuedDefinition,
+  ParameterDefinition,
+  InterfaceDefinition,
+  OperationDefinition,
+  UnionDefinition,
+  EnumDefinition,
+  EnumValueDefinition,
+  DirectiveDefinition,
+  DirectiveRequire,
+} from "../ast/index.ts";
+import { Kind } from "./kinds.ts";
+import { Context, Visitor } from "./visitor.ts";
+import {
+  Type as ASTType,
+  ListType as ASTListType,
+  MapType as ASTMapType,
+  Optional as ASTOptional,
+} from "../ast/index.ts";
+
+class Base {
+  readonly kind: Kind;
+
+  constructor(kind: Kind) {
+    this.kind = kind;
+  }
+}
+
+export enum PrimitiveName {
+  ID = "ID",
+  String = "string",
+  U8 = "u8",
+  U16 = "u16",
+  U32 = "u32",
+  U64 = "u64",
+  I8 = "i8",
+  I16 = "i16",
+  I32 = "i32",
+  I64 = "i64",
+  F32 = "f32",
+  F64 = "f64",
+  DateTime = "datetime",
+  Bool = "bool",
+  Bytes = "bytes",
+  Any = "any",
+  Value = "value",
+}
+
+export class Void extends Base {
+  constructor() {
+    super(Kind.Void);
+  }
+}
+
+export const VoidValue = new Void();
+
+export interface Named {
+  readonly name: string;
+}
+
+export class Primitive extends Base {
+  readonly name: PrimitiveName;
+
+  constructor(name: PrimitiveName) {
+    super(Kind.Primitive);
+    this.name = name;
+  }
+}
+
+export const primitives: { [name: string]: Primitive } = {
+  ID: new Primitive(PrimitiveName.ID),
+  string: new Primitive(PrimitiveName.String),
+  u8: new Primitive(PrimitiveName.U8),
+  u16: new Primitive(PrimitiveName.U16),
+  u32: new Primitive(PrimitiveName.U32),
+  u64: new Primitive(PrimitiveName.U64),
+  i8: new Primitive(PrimitiveName.I8),
+  i16: new Primitive(PrimitiveName.I16),
+  i32: new Primitive(PrimitiveName.I32),
+  i64: new Primitive(PrimitiveName.I64),
+  f32: new Primitive(PrimitiveName.F32),
+  f64: new Primitive(PrimitiveName.F64),
+  datetime: new Primitive(PrimitiveName.DateTime),
+  bool: new Primitive(PrimitiveName.Bool),
+  bytes: new Primitive(PrimitiveName.Bytes),
+  any: new Primitive(PrimitiveName.Any),
+  value: new Primitive(PrimitiveName.Value),
+};
+
+export class List extends Base {
+  readonly type: AnyType;
+
+  constructor(tr: TypeResolver, def: ASTListType) {
+    super(Kind.List);
+    this.type = tr(def.type);
+  }
+}
+
+export class Map extends Base {
+  readonly keyType: AnyType;
+  readonly valueType: AnyType;
+
+  constructor(tr: TypeResolver, def: ASTMapType) {
+    super(Kind.Map);
+    this.keyType = tr(def.keyType);
+    this.valueType = tr(def.valueType);
+  }
+}
+
+export class Optional extends Base {
+  readonly type: AnyType;
+
+  constructor(tr: TypeResolver, def: ASTOptional) {
+    super(Kind.Optional);
+    this.type = tr(def.type);
+  }
+}
+
+export class Stream extends Base {
+  type: AnyType;
+
+  constructor(tr: TypeResolver, def: ASTOptional) {
+    super(Kind.Stream);
+    this.type = tr(def.type);
+  }
+}
+
+export type AnyType =
+  | Primitive
+  | Alias
+  | Type
+  | Union
+  | Enum
+  | List
+  | Map
+  | Optional
+  | Stream
+  | Void;
+
+export abstract class Annotated extends Base {
+  readonly annotations: Annotation[];
+
+  constructor(kind: Kind, annotations: AnnotationDef[]) {
+    super(kind);
+    this.annotations = annotations.map((v) => new Annotation(v));
+  }
+
+  annotation(
+    name: string,
+    callback?: (annotation: Annotation) => void
+  ): Annotation | undefined {
+    return getAnnotation(name, this.annotations, callback);
+  }
+}
+
+export type TypeResolver = (name: ASTType) => AnyType;
+
+export class Namespace extends Annotated {
+  readonly node: NamespaceDefinition;
+  readonly name: string;
+  readonly description?: string;
+
+  readonly directives: { [name: string]: Directive };
+  readonly aliases: { [name: string]: Alias };
+  readonly functions: { [name: string]: Operation };
+  readonly interfaces: { [name: string]: Interface };
+  readonly types: { [name: string]: Type };
+  readonly enums: { [name: string]: Enum };
+  readonly unions: { [name: string]: Union };
+  readonly allTypes: { [name: string]: AnyType };
+
+  constructor(tr: TypeResolver, node: NamespaceDefinition) {
+    super(Kind.Namespace, node.annotations);
+    this.node = node;
+    this.name = node.name.value;
+    this.description = node.description?.value;
+    this.directives = {};
+    this.functions = {};
+    this.interfaces = {};
+    this.types = {};
+    this.enums = {};
+    this.unions = {};
+    this.aliases = {};
+    this.allTypes = {};
+  }
+
+  public accept(context: Context, visitor: Visitor): void {
+    context = context.clone({ namespace: this });
+    visitor.visitNamespaceBefore(context);
+    visitor.visitNamespace(context);
+
+    visitor.visitDirectivesBefore(context);
+    for (let name in this.directives) {
+      const item = this.directives[name];
+      item.accept(context.clone({ directive: item }), visitor);
+    }
+    visitor.visitDirectivesAfter(context);
+
+    visitor.visitAliasesBefore(context);
+    for (let name in this.aliases) {
+      const item = this.aliases[name];
+      if (!item.annotation("novisit")) {
+        item.accept(context.clone({ alias: item }), visitor);
+      }
+    }
+    visitor.visitAliasesAfter(context);
+
+    visitor.visitAllOperationsBefore(context);
+
+    visitor.visitFunctionsBefore(context);
+    for (let name in this.functions) {
+      const item = this.functions[name];
+      item.accept(context.clone({ operation: item }), visitor);
+    }
+    visitor.visitFunctionsAfter(context);
+
+    visitor.visitInterfacesBefore(context);
+    for (let name in this.interfaces) {
+      const item = this.interfaces[name];
+      item.accept(context.clone({ interface: item }), visitor);
+    }
+    visitor.visitInterfacesAfter(context);
+
+    visitor.visitAllOperationsAfter(context);
+
+    visitor.visitTypesBefore(context);
+    for (let name in this.types) {
+      const item = this.types[name];
+      if (!item.annotation("novisit")) {
+        item.accept(context.clone({ type: item }), visitor);
+      }
+    }
+    visitor.visitTypesAfter(context);
+
+    visitor.visitUnionsBefore(context);
+    for (let name in this.unions) {
+      const item = this.unions[name];
+      if (!item.annotation("novisit")) {
+        item.accept(context.clone({ union: item }), visitor);
+      }
+    }
+    visitor.visitUnionsAfter(context);
+
+    visitor.visitEnumsBefore(context);
+    for (let name in this.enums) {
+      const item = this.enums[name];
+      if (!item.annotation("novisit")) {
+        item.accept(context.clone({ enumDef: item }), visitor);
+      }
+    }
+    visitor.visitEnumsAfter(context);
+
+    visitor.visitNamespaceAfter(context);
+  }
+}
+
+export class Alias extends Annotated implements Named {
+  readonly node: AliasDefinition;
+  readonly name: string;
+  readonly description?: string;
+  readonly type: AnyType;
+
+  constructor(
+    tr: TypeResolver,
+    node: AliasDefinition,
+    register?: (a: Alias) => void
+  ) {
+    super(Kind.Alias, node.annotations);
+    this.node = node;
+    this.name = node.name.value;
+    this.description = node.description?.value;
+    if (register) {
+      register(this);
+    }
+    this.type = tr(node.type);
+  }
+
+  public accept(context: Context, visitor: Visitor): void {
+    visitor.visitAlias(context);
+  }
+}
+
+export class Type extends Annotated implements Named {
+  readonly node: TypeDefinition;
+  readonly name: string;
+  readonly description?: string;
+  readonly fields: Field[];
+
+  constructor(
+    tr: TypeResolver,
+    node: TypeDefinition,
+    register?: (a: Type) => void
+  ) {
+    super(Kind.Type, node.annotations);
+    this.node = node;
+    this.name = node.name.value;
+    this.description = node.description?.value;
+    if (register) {
+      register(this);
+    }
+    this.fields = node.fields.map((v) => new Field(tr, v));
+  }
+
+  public accept(context: Context, visitor: Visitor): void {
+    visitor.visitTypeBefore(context);
+    visitor.visitType(context);
+
+    context = context.clone({ fields: this.fields });
+    visitor.visitTypeFieldsBefore(context);
+    context.fields!.map((field, index) => {
+      field.accept(context.clone({ field: field, fieldIndex: index }), visitor);
+    });
+    visitor.visitTypeFieldsAfter(context);
+    visitor.visitTypeAfter(context);
+  }
+}
+
+export abstract class Valued extends Annotated implements Named {
+  readonly name: string;
+  readonly description?: string;
+  readonly type: AnyType;
+  readonly default?: Value;
+
+  constructor(tr: TypeResolver, kind: Kind, node: ValuedDefinition) {
+    super(kind, node.annotations);
+    this.name = node.name.value;
+    this.description = node.description?.value;
+    this.type = tr(node.type);
+  }
+}
+
+export class Field extends Valued {
+  readonly node: FieldDefinition;
+
+  constructor(tr: TypeResolver, node: FieldDefinition) {
+    super(tr, Kind.Field, node);
+    this.node = node;
+  }
+
+  public accept(context: Context, visitor: Visitor): void {
+    visitor.visitTypeField(context);
+  }
+}
+
+export class Interface extends Annotated implements Named {
+  readonly node: InterfaceDefinition;
+  readonly name: string;
+  readonly description?: string;
+  readonly operations: Operation[];
+
+  constructor(
+    tr: TypeResolver,
+    node: InterfaceDefinition,
+    register?: (r: Interface) => void
+  ) {
+    super(Kind.Interface, node.annotations);
+    this.node = node;
+    this.name = node.name.value;
+    this.description = node.description?.value;
+    if (register) {
+      register(this);
+    }
+    this.operations = node.operations.map((v) => new Operation(tr, v));
+  }
+
+  public accept(context: Context, visitor: Visitor): void {
+    visitor.visitInterfaceBefore(context);
+    visitor.visitInterface(context);
+
+    context = context.clone({ operations: this.operations });
+    visitor.visitOperationsBefore(context);
+    context.operations!.map((operation) => {
+      operation.accept(context.clone({ operation: operation }), visitor);
+    });
+
+    visitor.visitOperationsAfter(context);
+    visitor.visitInterfaceAfter(context);
+  }
+}
+
+export class Operation extends Annotated implements Named {
+  readonly node: OperationDefinition;
+  readonly name: string;
+  readonly description?: string;
+  readonly parameters: Parameter[];
+  readonly type: AnyType;
+  readonly unary: boolean;
+
+  constructor(
+    tr: TypeResolver,
+    node: OperationDefinition,
+    register?: (r: Operation) => void
+  ) {
+    super(Kind.Operation, node.annotations);
+    this.node = node;
+    this.name = node.name.value;
+    this.description = node.description?.value;
+    if (register) {
+      register(this);
+    }
+    this.parameters = node.parameters.map((v) => new Parameter(tr, v));
+    this.type = tr(node.type);
+    this.unary = node.unary;
+  }
+
+  public isUnary(): boolean {
+    return this.unary && this.parameters && this.parameters.length == 1;
+  }
+
+  public unaryOp(): Parameter {
+    return this.parameters[0];
+  }
+
+  public accept(context: Context, visitor: Visitor): void {
+    if (context.interface) {
+      visitor.visitOperationBefore(context);
+      visitor.visitOperation(context);
+    } else {
+      visitor.visitFunctionBefore(context);
+      visitor.visitFunction(context);
+    }
+
+    context = context.clone({ parameters: this.parameters });
+    visitor.visitParametersBefore(context);
+    context.parameters.map((parameter, index) => {
+      parameter.accept(
+        context.clone({ parameter: parameter, parameterIndex: index }),
+        visitor
+      );
+    });
+    visitor.visitParametersAfter(context);
+
+    if (context.interface) {
+      visitor.visitOperationAfter(context);
+    } else {
+      visitor.visitFunctionAfter(context);
+    }
+  }
+}
+
+export class Parameter extends Valued {
+  readonly node: ParameterDefinition;
+
+  constructor(tr: TypeResolver, node: ParameterDefinition) {
+    super(tr, Kind.Parameter, node);
+    this.node = node;
+  }
+
+  public accept(context: Context, visitor: Visitor): void {
+    if (context.operation != undefined) {
+      visitor.visitParameter(context);
+    } else if (context.directive != undefined) {
+      visitor.visitDirectiveParameter(context);
+    }
+  }
+}
+
+export class Union extends Annotated implements Named {
+  readonly node: UnionDefinition;
+  readonly name: string;
+  readonly description?: string;
+  readonly types: AnyType[];
+
+  constructor(
+    tr: TypeResolver,
+    node: UnionDefinition,
+    register?: (a: Union) => void
+  ) {
+    super(Kind.Union, node.annotations);
+    this.node = node;
+    this.name = node.name.value;
+    this.description = node.description?.value;
+    if (register) {
+      register(this);
+    }
+    this.types = node.types.map((v) => tr(v));
+  }
+
+  public accept(context: Context, visitor: Visitor): void {
+    visitor.visitUnion(context);
+  }
+}
+
+export class Enum extends Annotated implements Named {
+  readonly node: EnumDefinition;
+  readonly name: string;
+  readonly description?: string;
+  readonly values: EnumValue[];
+
+  constructor(
+    tr: TypeResolver,
+    node: EnumDefinition,
+    register?: (e: Enum) => void
+  ) {
+    super(Kind.Enum, node.annotations);
+    this.node = node;
+    this.name = node.name.value;
+    this.description = node.description?.value;
+    if (register) {
+      register(this);
+    }
+    this.values = node.values.map((v) => new EnumValue(tr, v));
+  }
+
+  public accept(context: Context, visitor: Visitor): void {
+    visitor.visitEnumBefore(context);
+    visitor.visitEnum(context);
+
+    context = context.clone({ enumValues: this.values });
+    visitor.visitEnumValuesBefore(context);
+    context.enumValues!.map((enumValue) => {
+      enumValue.accept(context.clone({ enumValue: enumValue }), visitor);
+    });
+
+    visitor.visitEnumValuesAfter(context);
+    visitor.visitEnumAfter(context);
+  }
+}
+
+export class EnumValue extends Annotated implements Named {
+  readonly node: EnumValueDefinition;
+  readonly name: string;
+  readonly description?: string;
+  readonly index: number;
+  readonly display?: string;
+
+  constructor(tr: TypeResolver, node: EnumValueDefinition) {
+    super(Kind.EnumValue, node.annotations);
+    this.node = node;
+    this.name = node.name.value;
+    this.description = node.description?.value;
+    this.index = node.index.value;
+    this.display = node.display?.value;
+  }
+
+  public accept(context: Context, visitor: Visitor): void {
+    visitor.visitEnumValue(context);
+  }
+}
+
+export class Directive extends Base implements Named {
+  readonly node: DirectiveDefinition;
+  readonly name: string;
+  readonly description?: string;
+  readonly parameters: Parameter[];
+  readonly locations: string[];
+  readonly requires: Require[];
+
+  constructor(
+    tr: TypeResolver,
+    node: DirectiveDefinition,
+    register?: (r: Directive) => void
+  ) {
+    super(Kind.Directive);
+    this.node = node;
+    this.name = node.name.value;
+    this.description = node.description?.value;
+    if (register) {
+      register(this);
+    }
+    this.parameters = node.parameters.map((v) => new Parameter(tr, v));
+    this.locations = node.locations.map((v) => v.value);
+    this.requires = node.requires.map((v) => new Require(tr, v));
+  }
+
+  public hasLocation(location: string): boolean {
+    for (let l of this.locations) {
+      if (l == location) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public accept(context: Context, visitor: Visitor): void {
+    visitor.visitDirectiveBefore(context);
+    visitor.visitDirective(context);
+
+    context = context.clone({ parameters: this.parameters });
+    visitor.visitDirectiveParametersBefore(context);
+    context.parameters!.map((parameter, index) => {
+      parameter.accept(
+        context.clone({ parameter: parameter, parameterIndex: index }),
+        visitor
+      );
+    });
+
+    visitor.visitDirectiveParametersAfter(context);
+    visitor.visitDirectiveAfter(context);
+  }
+}
+
+export class Require extends Base {
+  readonly node: DirectiveRequire;
+  readonly directive: string;
+  readonly locations: string[];
+
+  constructor(tr: TypeResolver, node: DirectiveRequire) {
+    super(Kind.Require);
+    this.node = node;
+    this.directive = node.directive.value;
+    this.locations = node.locations.map((v) => v.value);
+  }
+
+  public hasLocation(location: string): boolean {
+    for (let l of this.locations) {
+      if (l == location) {
+        return true;
+      }
+    }
+    return false;
+  }
+}
+
+export class Annotation extends Base implements Named {
+  readonly node: AnnotationDef;
+  readonly name: string;
+  readonly arguments: Argument[];
+
+  constructor(node: AnnotationDef) {
+    super(Kind.Annotation);
+    this.node = node;
+    this.name = node.name.value;
+    this.arguments = node.arguments.map((v) => new Argument(v));
+  }
+
+  convert<T>(): T {
+    let obj: { [k: string]: any } = {};
+    this.arguments.map((arg) => {
+      obj[arg.name] = arg.value.getValue();
+    });
+    return obj as T;
+  }
+
+  public accept(context: Context, visitor: Visitor): void {
+    visitor.visitAnnotation(context);
+  }
+}
+
+export class Argument extends Base implements Named {
+  readonly node: ArgumentDef;
+  readonly name: string;
+  readonly value: Value;
+
+  constructor(node: ArgumentDef) {
+    super(Kind.Argument);
+    this.node = node;
+    this.name = node.name.value;
+    this.value = node.value;
+  }
+}
+
+function getAnnotation(
+  name: string,
+  annotations?: Annotation[],
+  callback?: (annotation: Annotation) => void
+): Annotation | undefined {
+  if (annotations == undefined) {
+    return undefined;
+  }
+  for (let a of annotations!) {
+    if (a.name === name) {
+      if (callback != undefined) {
+        callback(a);
+      }
+      return a;
+    }
+  }
+  return undefined;
+}

--- a/deno_dist/model/visitor.ts
+++ b/deno_dist/model/visitor.ts
@@ -1,0 +1,1328 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import {
+  Namespace,
+  AnyType,
+  Interface,
+  Enum,
+  Union,
+  Parameter,
+  Field,
+  Operation,
+  EnumValue,
+  Directive,
+  Alias,
+  Type as MObject,
+  Optional,
+  List,
+  Map,
+  Stream,
+  primitives,
+  VoidValue,
+} from "./model.ts";
+import {
+  Document,
+  Annotation,
+  NamespaceDefinition,
+  DirectiveDefinition,
+  AliasDefinition,
+  InterfaceDefinition,
+  TypeDefinition,
+  EnumDefinition,
+  UnionDefinition,
+  Named,
+  Name,
+  OperationDefinition,
+} from "../ast/index.ts";
+import autoBind from "../auto-bind.ts";
+import { ApexError } from "../error/index.ts";
+import { Kind } from "../ast/index.ts";
+import {
+  Type as ASTType,
+  Kind as ASTKind,
+  ListType as ASTListType,
+  MapType as ASTMapType,
+  Optional as ASTOptional,
+  Stream as ASTStream,
+} from "../ast/index.ts";
+
+export class Writer {
+  private code: string = "";
+
+  write(source: string) {
+    this.code += source;
+  }
+
+  string(): string {
+    return this.code;
+  }
+}
+
+export type ObjectMap<T = any> = { [key: string]: T };
+
+interface NamedParameters {
+  namespace?: Namespace;
+  directive?: Directive;
+  alias?: Alias;
+  interface?: Interface;
+  type?: MObject;
+  operations?: Operation[];
+  operation?: Operation;
+  parameters?: Parameter[];
+  parameter?: Parameter;
+  parameterIndex?: number;
+  fields?: Field[];
+  field?: Field;
+  fieldIndex?: number;
+  enumDef?: Enum;
+  enumValues?: EnumValue[];
+  enumValue?: EnumValue;
+  union?: Union;
+  annotation?: Annotation;
+}
+
+class ErrorHolder {
+  errors: ApexError[];
+
+  constructor() {
+    this.errors = new Array<ApexError>();
+  }
+
+  reportError(error: ApexError): void {
+    this.errors.push(error);
+  }
+}
+
+function dummyValue<T>(fieldName: string): T {
+  return undefined as unknown as T;
+}
+
+export class Context {
+  config: ObjectMap;
+  document?: Document;
+
+  // Top-level definitions
+  namespaces: Namespace[];
+
+  // Drill-down definitions
+  namespace: Namespace;
+  namespacePos: number = dummyValue<number>("namespacePos");
+  directive: Directive = dummyValue<Directive>("directive");
+  alias: Alias = dummyValue<Alias>("alias");
+  interface: Interface = dummyValue<Interface>("interface");
+  type: MObject = dummyValue<MObject>("type");
+  operations: Operation[] = dummyValue<Operation[]>("operations");
+  operation: Operation = dummyValue<Operation>("operation");
+  parameters: Parameter[] = dummyValue<Parameter[]>("parameters");
+  parameter: Parameter = dummyValue<Parameter>("parameter");
+  parameterIndex: number = dummyValue<number>("parameterIndex");
+  fields: Field[] = dummyValue<Field[]>("fields");
+  field: Field = dummyValue<Field>("fields");
+  fieldIndex: number = dummyValue<number>("fieldIndex");
+  enum: Enum = dummyValue<Enum>("enum");
+  enumValues: EnumValue[] = dummyValue<EnumValue[]>("enumValues");
+  enumValue: EnumValue = dummyValue<EnumValue>("enumValue");
+  union: Union = dummyValue<Union>("union");
+
+  annotations: Annotation[] = dummyValue<Annotation[]>("annotations");
+  annotation: Annotation = dummyValue<Annotation>("annotation");
+
+  private errors: ErrorHolder;
+  private typeMap: {
+    [name: string]:
+      | AliasDefinition
+      | TypeDefinition
+      | UnionDefinition
+      | EnumDefinition;
+  };
+
+  constructor(config: ObjectMap, document?: Document, other?: Context) {
+    this.config = config || {};
+    this.namespace = new Namespace(
+      this.getType.bind(this),
+      new NamespaceDefinition(
+        undefined,
+        new Name(undefined, "undefined"),
+        undefined
+      )
+    );
+
+    if (other != undefined) {
+      this.document = other.document;
+      this.namespace = other.namespace;
+      this.namespaces = other.namespaces;
+      // this.annotations = other.annotations;
+      // this.annotation = other.annotation;
+
+      this.errors = other.errors;
+      this.typeMap = other.typeMap;
+    } else {
+      this.namespaces = [];
+      // this.annotations = [];
+
+      this.errors = new ErrorHolder();
+      this.typeMap = {};
+    }
+
+    if (this.document == undefined && document != undefined) {
+      this.document = document!;
+      this.parseDocument();
+    } else if (!other) {
+      throw new Error("document or context is required");
+    }
+
+    autoBind(this);
+  }
+
+  clone({
+    namespace,
+    directive,
+    alias,
+    interface: iface,
+    type,
+    operations,
+    operation,
+    parameters,
+    parameter,
+    parameterIndex,
+    fields,
+    field,
+    fieldIndex,
+    enumDef,
+    enumValues,
+    enumValue,
+    union,
+    annotation,
+  }: NamedParameters): Context {
+    var context = new Context(this.config, undefined, this);
+
+    context.namespace = namespace || this.namespace;
+    context.namespacePos = this.namespacePos;
+    context.directive = directive || this.directive;
+    context.alias = alias || this.alias;
+    context.interface = iface || this.interface;
+    context.type = type || this.type;
+    context.operations = operations || this.operations;
+    context.operation = operation || this.operation;
+    context.parameters = parameters || this.parameters;
+    context.parameter = parameter || this.parameter;
+    context.parameterIndex = parameterIndex || this.parameterIndex;
+    context.fields = fields || this.fields;
+    context.field = field || this.field;
+    context.fieldIndex = fieldIndex || this.fieldIndex;
+    context.enum = enumDef || this.enum;
+    context.enumValues = enumValues || this.enumValues;
+    context.enumValue = enumValue || this.enumValue;
+    context.union = union || this.union;
+    context.annotation = annotation || this.annotation;
+
+    return context;
+  }
+
+  private parseDocument() {
+    this.document!.definitions.forEach((value, index) => {
+      switch (value.getKind()) {
+        // There is one namespace per document.
+        case Kind.NamespaceDefinition:
+          const namespace = new Namespace(
+            this.getType.bind(this),
+            value as NamespaceDefinition
+          );
+          this.namespaces.push(namespace);
+          this.namespace = namespace;
+          this.namespacePos = index;
+          break;
+        case Kind.AliasDefinition:
+          const aliasDef = value as AliasDefinition;
+          this.typeMap[aliasDef.name.value] = aliasDef;
+          break;
+        case Kind.TypeDefinition:
+          const typeDef = value as TypeDefinition;
+          this.typeMap[typeDef.name.value] = typeDef;
+          break;
+        case Kind.EnumDefinition:
+          const enumDef = value as EnumDefinition;
+          this.typeMap[enumDef.name.value] = enumDef;
+          break;
+        case Kind.UnionDefinition:
+          const unionDef = value as UnionDefinition;
+          this.typeMap[unionDef.name.value] = unionDef;
+          break;
+      }
+    });
+
+    if (!this.namespace || this.namespace.name == "undefined") {
+      throw new Error("namespace not found");
+    }
+
+    this.document!.definitions.forEach((value) => {
+      switch (value.getKind()) {
+        case Kind.AliasDefinition:
+          const aliasDef = value as AliasDefinition;
+          if (!this.namespace.allTypes[aliasDef.name.value]) {
+            new Alias(this.getType.bind(this), aliasDef, (a: Alias) => {
+              this.namespace.aliases[a.name] = a;
+              this.namespace.allTypes[a.name] = a;
+            });
+          }
+          break;
+        case Kind.TypeDefinition:
+          const typeDef = value as TypeDefinition;
+          if (!this.namespace.allTypes[typeDef.name.value]) {
+            new MObject(this.getType.bind(this), typeDef, (t: MObject) => {
+              this.namespace.types[t.name] = t;
+              this.namespace.allTypes[t.name] = t;
+            });
+          }
+          break;
+        case Kind.EnumDefinition:
+          const enumDef = value as EnumDefinition;
+          if (!this.namespace.allTypes[enumDef.name.value]) {
+            new Enum(this.getType.bind(this), enumDef, (e: Enum) => {
+              this.namespace.enums[e.name] = e;
+              this.namespace.allTypes[e.name] = e;
+            });
+          }
+          break;
+        case Kind.UnionDefinition:
+          const unionDef = value as UnionDefinition;
+          if (!this.namespace.allTypes[unionDef.name.value]) {
+            new Union(this.getType.bind(this), unionDef, (u: Union) => {
+              this.namespace.unions[u.name] = u;
+              this.namespace.allTypes[u.name] = u;
+            });
+          }
+          break;
+      }
+    });
+
+    this.document!.definitions.forEach((value) => {
+      switch (value.getKind()) {
+        case Kind.DirectiveDefinition:
+          new Directive(
+            this.getType.bind(this),
+            value as DirectiveDefinition,
+            (d: Directive) => {
+              this.namespace.directives[d.name] = d;
+            }
+          );
+          break;
+        case Kind.OperationDefinition:
+          new Operation(
+            this.getType.bind(this),
+            value as OperationDefinition,
+            (r: Operation) => {
+              this.namespace.functions[r.name] = r;
+            }
+          );
+          break;
+        case Kind.InterfaceDefinition:
+          new Interface(
+            this.getType.bind(this),
+            value as InterfaceDefinition,
+            (r: Interface) => {
+              this.namespace.interfaces[r.name] = r;
+            }
+          );
+          break;
+      }
+    });
+
+    // Reorder all types per the contents of the spec document.
+    this.document!.definitions.forEach((value) => {
+      switch (value.getKind()) {
+        case Kind.AliasDefinition:
+          const aliasDef = value as AliasDefinition;
+          const a = this.namespace.aliases[aliasDef.name.value];
+          delete this.namespace.aliases[a.name];
+          delete this.namespace.allTypes[a.name];
+          this.namespace.aliases[a.name] = a;
+          this.namespace.allTypes[a.name] = a;
+          break;
+        case Kind.TypeDefinition:
+          const typeDef = value as TypeDefinition;
+          const t = this.namespace.types[typeDef.name.value];
+          delete this.namespace.types[t.name];
+          delete this.namespace.allTypes[t.name];
+          this.namespace.types[t.name] = t;
+          this.namespace.allTypes[t.name] = t;
+          break;
+        case Kind.EnumDefinition:
+          const enumDef = value as EnumDefinition;
+          const e = this.namespace.enums[enumDef.name.value];
+          delete this.namespace.enums[e.name];
+          delete this.namespace.allTypes[e.name];
+          this.namespace.enums[e.name] = e;
+          this.namespace.allTypes[e.name] = e;
+          break;
+        case Kind.UnionDefinition:
+          const unionDef = value as UnionDefinition;
+          const u = this.namespace.unions[unionDef.name.value];
+          delete this.namespace.unions[u.name];
+          delete this.namespace.allTypes[u.name];
+          this.namespace.unions[u.name] = u;
+          this.namespace.allTypes[u.name] = u;
+          break;
+      }
+    });
+  }
+
+  reportError(error: ApexError): void {
+    this.errors.reportError(error);
+  }
+
+  getErrors(): ApexError[] {
+    return this.errors.errors;
+  }
+
+  getType(t: ASTType): AnyType {
+    switch (t.getKind()) {
+      case ASTKind.Named:
+        const name = (t as Named).name.value;
+        if (name === "void") {
+          return VoidValue;
+        }
+
+        let namedType = this.namespace.allTypes[name];
+        if (namedType != undefined) {
+          return namedType;
+        }
+
+        namedType = primitives[name];
+        if (namedType != undefined) {
+          return namedType;
+        }
+
+        const anyTypeDef = this.typeMap[name];
+        if (!anyTypeDef) {
+          throw new Error(`Unknown type ${name}`);
+        }
+
+        switch (anyTypeDef.getKind()) {
+          case ASTKind.AliasDefinition:
+            return new Alias(
+              this.getType.bind(this),
+              anyTypeDef as AliasDefinition,
+              (a: Alias) => {
+                this.namespace.aliases[a.name] = a;
+                this.namespace.allTypes[a.name] = a;
+              }
+            );
+          case ASTKind.TypeDefinition:
+            return new MObject(
+              this.getType.bind(this),
+              anyTypeDef as TypeDefinition,
+              (t: MObject) => {
+                this.namespace.types[t.name] = t;
+                this.namespace.allTypes[t.name] = t;
+              }
+            );
+          case ASTKind.UnionDefinition:
+            return new Union(
+              this.getType.bind(this),
+              anyTypeDef as UnionDefinition,
+              (u: Union) => {
+                this.namespace.unions[u.name] = u;
+                this.namespace.allTypes[u.name] = u;
+              }
+            );
+          case ASTKind.EnumDefinition:
+            return new Enum(
+              this.getType.bind(this),
+              anyTypeDef as EnumDefinition,
+              (e: Enum) => {
+                this.namespace.enums[e.name] = e;
+                this.namespace.allTypes[e.name] = e;
+              }
+            );
+        }
+
+        break;
+      case ASTKind.Optional:
+        const optional = t as ASTOptional;
+        return new Optional(this.getType.bind(this), optional);
+      case ASTKind.ListType:
+        const list = t as ASTListType;
+        return new List(this.getType.bind(this), list);
+      case ASTKind.MapType:
+        const map = t as ASTMapType;
+        return new Map(this.getType.bind(this), map);
+      case ASTKind.Stream:
+        const stream = t as ASTStream;
+        return new Stream(this.getType.bind(this), stream);
+    }
+
+    throw new Error("could not resolve type: " + t);
+  }
+
+  accept(context: Context, visitor: Visitor): void {
+    visitor.visitContextBefore(context);
+    context.namespaces.map((namespace) => {
+      namespace.accept(context.clone({ namespace: namespace }), visitor);
+    });
+    visitor.visitContextAfter(context);
+  }
+}
+
+export interface Visitor {
+  visitContextBefore(context: Context): void;
+  visitContextAfter(context: Context): void;
+
+  visitNamespaceBefore(context: Context): void;
+  visitNamespace(context: Context): void;
+  visitNamespaceAfter(context: Context): void;
+
+  visitImportsBefore(context: Context): void;
+  visitImport(context: Context): void;
+  visitImportsAfter(context: Context): void;
+
+  visitDirectivesBefore(context: Context): void;
+  visitDirectiveBefore(context: Context): void;
+  visitDirective(context: Context): void;
+  visitDirectiveParametersBefore(context: Context): void;
+  visitDirectiveParameter(context: Context): void;
+  visitDirectiveParametersAfter(context: Context): void;
+  visitDirectiveAfter(context: Context): void;
+  visitDirectivesAfter(context: Context): void;
+
+  visitAliasesBefore(context: Context): void;
+  visitAliasBefore(context: Context): void;
+  visitAlias(context: Context): void;
+  visitAliasAfter(context: Context): void;
+  visitAliasesAfter(context: Context): void;
+
+  visitAllOperationsBefore(context: Context): void;
+  visitFunctionsBefore(context: Context): void;
+  visitFunctionBefore(context: Context): void;
+  visitFunction(context: Context): void;
+  visitFunctionAfter(context: Context): void;
+  visitFunctionsAfter(context: Context): void;
+  visitInterfacesBefore(context: Context): void;
+  visitInterfaceBefore(context: Context): void;
+  visitInterface(context: Context): void;
+  visitOperationsBefore(context: Context): void;
+  visitOperationBefore(context: Context): void;
+  visitOperation(context: Context): void;
+  visitParametersBefore(context: Context): void;
+  visitParameter(context: Context): void;
+  visitParametersAfter(context: Context): void;
+  visitOperationAfter(context: Context): void;
+  visitOperationsAfter(context: Context): void;
+  visitInterfaceAfter(context: Context): void;
+  visitInterfacesAfter(context: Context): void;
+  visitAllOperationsAfter(context: Context): void;
+
+  visitTypesBefore(context: Context): void;
+  visitTypeBefore(context: Context): void;
+  visitType(context: Context): void;
+  visitTypeFieldsBefore(context: Context): void;
+  visitTypeField(context: Context): void;
+  visitTypeFieldsAfter(context: Context): void;
+  visitTypeAfter(context: Context): void;
+  visitTypesAfter(context: Context): void;
+
+  visitEnumsBefore(context: Context): void;
+  visitEnumBefore(context: Context): void;
+  visitEnum(context: Context): void;
+  visitEnumValuesBefore(context: Context): void;
+  visitEnumValue(context: Context): void;
+  visitEnumValuesAfter(context: Context): void;
+  visitEnumAfter(context: Context): void;
+  visitEnumsAfter(context: Context): void;
+
+  visitUnionsBefore(context: Context): void;
+  visitUnion(context: Context): void;
+  visitUnionsAfter(context: Context): void;
+
+  visitAnnotationsBefore(context: Context): void;
+  visitAnnotationBefore(context: Context): void;
+  visitAnnotation(context: Context): void;
+  visitAnnotationArgumentsBefore(context: Context): void;
+  visitAnnotationArgument(context: Context): void;
+  visitAnnotationArgumentsAfter(context: Context): void;
+  visitAnnotationAfter(context: Context): void;
+  visitAnnotationsAfter(context: Context): void;
+}
+
+export type Callbacks = { [name: string]: { [name: string]: VisitorCallback } };
+export type VisitorCallback = (_context: Context) => void;
+
+export abstract class AbstractVisitor implements Visitor {
+  callbacks: Callbacks = {};
+
+  setCallback(phase: string, purpose: string, callback: VisitorCallback): void {
+    var purposes = this.callbacks[phase];
+    if (purposes == undefined) {
+      purposes = {};
+      this.callbacks[phase] = purposes;
+    }
+    purposes[purpose] = callback;
+  }
+
+  triggerCallbacks(context: Context, phase: string): void {
+    var purposes = this.callbacks[phase];
+    if (purposes == undefined) {
+      return;
+    }
+    for (let name of Object.keys(purposes)) {
+      const callback = purposes[name];
+      callback(context);
+    }
+  }
+
+  public visitContextBefore(context: Context): void {
+    this.triggerContextBefore(context);
+  }
+  public triggerContextBefore(context: Context): void {
+    this.triggerCallbacks(context, "ContextBefore");
+  }
+
+  public visitContextAfter(context: Context): void {
+    this.triggerContextAfter(context);
+  }
+  public triggerContextAfter(context: Context): void {
+    this.triggerCallbacks(context, "ContextAfter");
+  }
+
+  public visitNamespaceBefore(context: Context): void {
+    this.triggerNamespaceBefore(context);
+  }
+  public triggerNamespaceBefore(context: Context): void {
+    this.triggerCallbacks(context, "NamespaceBefore");
+  }
+  public visitNamespace(context: Context): void {
+    this.triggerNamespace(context);
+  }
+  public triggerNamespace(context: Context): void {
+    this.triggerCallbacks(context, "Namespace");
+  }
+  public visitNamespaceAfter(context: Context): void {
+    this.triggerNamespaceAfter(context);
+  }
+  public triggerNamespaceAfter(context: Context): void {
+    this.triggerCallbacks(context, "NamespaceAfter");
+  }
+  public visitImportsBefore(context: Context): void {
+    this.triggerImportsBefore(context);
+  }
+  public triggerImportsBefore(context: Context): void {
+    this.triggerCallbacks(context, "ImportsBefore");
+  }
+  public visitImport(context: Context): void {
+    this.triggerImport(context);
+  }
+  public triggerImport(context: Context): void {
+    this.triggerCallbacks(context, "Import");
+  }
+  public visitImportsAfter(context: Context): void {
+    this.triggerImportsAfter(context);
+  }
+  public triggerImportsAfter(context: Context): void {
+    this.triggerCallbacks(context, "ImportsAfter");
+  }
+
+  public visitDirectivesBefore(context: Context): void {
+    this.triggerDirectivesBefore(context);
+  }
+  public triggerDirectivesBefore(context: Context): void {
+    this.triggerCallbacks(context, "DirectivesBefore");
+  }
+  public visitDirectiveBefore(context: Context): void {
+    this.triggerDirectiveBefore(context);
+  }
+  public triggerDirectiveBefore(context: Context): void {
+    this.triggerCallbacks(context, "DirectiveBefore");
+  }
+  public visitDirective(context: Context): void {
+    this.triggerDirective(context);
+  }
+  public triggerDirective(context: Context): void {
+    this.triggerCallbacks(context, "Directive");
+  }
+
+  public visitDirectiveParametersBefore(context: Context): void {
+    this.triggerDirectiveParametersBefore(context);
+  }
+  public triggerDirectiveParametersBefore(context: Context): void {
+    this.triggerCallbacks(context, "DirectiveParametersBefore");
+  }
+  public visitDirectiveParameter(context: Context): void {
+    this.triggerDirectiveParameter(context);
+  }
+  public triggerDirectiveParameter(context: Context): void {
+    this.triggerCallbacks(context, "DirectiveParameter");
+  }
+  public visitDirectiveParametersAfter(context: Context): void {
+    this.triggerDirectiveParametersAfter(context);
+  }
+  public triggerDirectiveParametersAfter(context: Context): void {
+    this.triggerCallbacks(context, "DirectiveParametersAfter");
+  }
+
+  public visitDirectiveAfter(context: Context): void {
+    this.triggerDirectiveBefore(context);
+  }
+  public triggerDirectiveAfter(context: Context): void {
+    this.triggerCallbacks(context, "DirectiveAfter");
+  }
+  public visitDirectivesAfter(context: Context): void {
+    this.triggerDirectivesAfter(context);
+  }
+  public triggerDirectivesAfter(context: Context): void {
+    this.triggerCallbacks(context, "DirectivesAfter");
+  }
+
+  public visitAliasesBefore(context: Context): void {
+    this.triggerAliasesBefore(context);
+  }
+  public triggerAliasesBefore(context: Context): void {
+    this.triggerCallbacks(context, "AliasesBefore");
+  }
+  public visitAliasBefore(context: Context): void {
+    this.triggerAliasBefore(context);
+  }
+  public triggerAliasBefore(context: Context): void {
+    this.triggerCallbacks(context, "AliasBefore");
+  }
+  public visitAlias(context: Context): void {
+    this.triggerAlias(context);
+  }
+  public triggerAlias(context: Context): void {
+    this.triggerCallbacks(context, "Alias");
+  }
+  public visitAliasAfter(context: Context): void {
+    this.triggerAliasBefore(context);
+  }
+  public triggerAliasAfter(context: Context): void {
+    this.triggerCallbacks(context, "AliasAfter");
+  }
+  public visitAliasesAfter(context: Context): void {
+    this.triggerAliasesAfter(context);
+  }
+  public triggerAliasesAfter(context: Context): void {
+    this.triggerCallbacks(context, "AliasesAfter");
+  }
+
+  public visitAllOperationsBefore(context: Context): void {
+    this.triggerAllOperationsBefore(context);
+  }
+  public triggerAllOperationsBefore(context: Context): void {
+    this.triggerCallbacks(context, "AllOperationsBefore");
+  }
+  public visitFunctionsBefore(context: Context): void {
+    this.triggerFunctionsBefore(context);
+  }
+  public triggerFunctionsBefore(context: Context): void {
+    this.triggerCallbacks(context, "FunctionsBefore");
+  }
+  public visitFunctionBefore(context: Context): void {
+    this.triggerFunctionBefore(context);
+  }
+  public triggerFunctionBefore(context: Context): void {
+    this.triggerCallbacks(context, "FunctionBefore");
+  }
+  public visitFunction(context: Context): void {
+    this.triggerFunction(context);
+  }
+  public triggerFunction(context: Context): void {
+    this.triggerCallbacks(context, "Function");
+  }
+  public visitFunctionAfter(context: Context): void {
+    this.triggerFunctionAfter(context);
+  }
+  public triggerFunctionAfter(context: Context): void {
+    this.triggerCallbacks(context, "FunctionAfter");
+  }
+  public visitFunctionsAfter(context: Context): void {
+    this.triggerFunctionsAfter(context);
+  }
+  public triggerFunctionsAfter(context: Context): void {
+    this.triggerCallbacks(context, "FunctionsAfter");
+  }
+  public visitInterfacesBefore(context: Context): void {
+    this.triggerInterfacesBefore(context);
+  }
+  public triggerInterfacesBefore(context: Context): void {
+    this.triggerCallbacks(context, "InterfacesBefore");
+  }
+  public visitInterfaceBefore(context: Context): void {
+    this.triggerInterfaceBefore(context);
+  }
+  public triggerInterfaceBefore(context: Context): void {
+    this.triggerCallbacks(context, "InterfaceBefore");
+  }
+  public visitInterface(context: Context): void {
+    this.triggerInterface(context);
+  }
+  public triggerInterface(context: Context): void {
+    this.triggerCallbacks(context, "Interface");
+  }
+  public visitOperationsBefore(context: Context): void {
+    this.triggerOperationsBefore(context);
+  }
+  public triggerOperationsBefore(context: Context): void {
+    this.triggerCallbacks(context, "OperationsBefore");
+  }
+  public visitOperationBefore(context: Context): void {
+    this.triggerOperationBefore(context);
+  }
+  public triggerOperationBefore(context: Context): void {
+    this.triggerCallbacks(context, "OperationBefore");
+  }
+  public visitOperation(context: Context): void {
+    this.triggerOperation(context);
+  }
+  public triggerOperation(context: Context): void {
+    this.triggerCallbacks(context, "Operation");
+  }
+  public visitParametersBefore(context: Context): void {
+    this.triggerParametersBefore(context);
+  }
+  public triggerParametersBefore(context: Context): void {
+    this.triggerCallbacks(context, "ParametersBefore");
+  }
+  public visitParameter(context: Context): void {
+    this.triggerParameter(context);
+  }
+  public triggerParameter(context: Context): void {
+    this.triggerCallbacks(context, "Parameter");
+  }
+  public visitParametersAfter(context: Context): void {
+    this.triggerParametersAfter(context);
+  }
+  public triggerParametersAfter(context: Context): void {
+    this.triggerCallbacks(context, "ParametersAfter");
+  }
+  public visitOperationAfter(context: Context): void {
+    this.triggerOperationAfter(context);
+  }
+  public triggerOperationAfter(context: Context): void {
+    this.triggerCallbacks(context, "OperationAfter");
+  }
+  public visitOperationsAfter(context: Context): void {
+    this.triggerOperationsAfter(context);
+  }
+  public triggerOperationsAfter(context: Context): void {
+    this.triggerCallbacks(context, "OperationsAfter");
+  }
+  public visitInterfaceAfter(context: Context): void {
+    this.triggerInterfaceAfter(context);
+  }
+  public triggerInterfaceAfter(context: Context): void {
+    this.triggerCallbacks(context, "InterfaceAfter");
+  }
+  public visitInterfacesAfter(context: Context): void {
+    this.triggerInterfacesAfter(context);
+  }
+  public triggerInterfacesAfter(context: Context): void {
+    this.triggerCallbacks(context, "InterfacesAfter");
+  }
+  public visitAllOperationsAfter(context: Context): void {
+    this.triggerAllOperationsAfter(context);
+  }
+  public triggerAllOperationsAfter(context: Context): void {
+    this.triggerCallbacks(context, "AllOperationsAfter");
+  }
+
+  public visitTypesBefore(context: Context): void {
+    this.triggerTypesBefore(context);
+  }
+  public triggerTypesBefore(context: Context): void {
+    this.triggerCallbacks(context, "TypesBefore");
+  }
+  public visitTypeBefore(context: Context): void {
+    this.triggerTypeBefore(context);
+  }
+  public triggerTypeBefore(context: Context): void {
+    this.triggerCallbacks(context, "TypeBefore");
+  }
+  public visitType(context: Context): void {
+    this.triggerType(context);
+  }
+  public triggerType(context: Context): void {
+    this.triggerCallbacks(context, "Type");
+  }
+  public visitTypeFieldsBefore(context: Context): void {
+    this.triggerTypeFieldsBefore(context);
+  }
+  public triggerTypeFieldsBefore(context: Context): void {
+    this.triggerCallbacks(context, "TypeFieldsBefore");
+  }
+  public visitTypeField(context: Context): void {
+    this.triggerTypeField(context);
+  }
+  public triggerTypeField(context: Context): void {
+    this.triggerCallbacks(context, "TypeField");
+  }
+  public visitTypeFieldsAfter(context: Context): void {
+    this.triggerTypeFieldsAfter(context);
+  }
+  public triggerTypeFieldsAfter(context: Context): void {
+    this.triggerCallbacks(context, "TypeFieldsAfter");
+  }
+  public visitTypeAfter(context: Context): void {
+    this.triggerTypeAfter(context);
+  }
+  public triggerTypeAfter(context: Context): void {
+    this.triggerCallbacks(context, "TypeAfter");
+  }
+  public visitTypesAfter(context: Context): void {
+    this.triggerTypesAfter(context);
+  }
+  public triggerTypesAfter(context: Context): void {
+    this.triggerCallbacks(context, "TypesAfter");
+  }
+
+  public visitEnumsBefore(context: Context): void {
+    this.triggerEnumsBefore(context);
+  }
+  public triggerEnumsBefore(context: Context): void {
+    this.triggerCallbacks(context, "EnumsBefore");
+  }
+  public visitEnumBefore(context: Context): void {
+    this.triggerEnumsBefore(context);
+  }
+  public triggerEnumBefore(context: Context): void {
+    this.triggerCallbacks(context, "EnumBefore");
+  }
+  public visitEnum(context: Context): void {
+    this.triggerEnum(context);
+  }
+  public triggerEnum(context: Context): void {
+    this.triggerCallbacks(context, "Enum");
+  }
+  public visitEnumValuesBefore(context: Context): void {
+    this.triggerEnumValuesBefore(context);
+  }
+  public triggerEnumValuesBefore(context: Context): void {
+    this.triggerCallbacks(context, "EnumValuesBefore");
+  }
+  public visitEnumValue(context: Context): void {
+    this.triggerEnumValue(context);
+  }
+  public triggerEnumValue(context: Context): void {
+    this.triggerCallbacks(context, "EnumValue");
+  }
+  public visitEnumValuesAfter(context: Context): void {
+    this.triggerEnumValuesAfter(context);
+  }
+  public triggerEnumValuesAfter(context: Context): void {
+    this.triggerCallbacks(context, "EnumValuesAfter");
+  }
+  public visitEnumAfter(context: Context): void {
+    this.triggerEnumsAfter(context);
+  }
+  public triggerEnumAfter(context: Context): void {
+    this.triggerCallbacks(context, "EnumAfter");
+  }
+  public visitEnumsAfter(context: Context): void {
+    this.triggerEnumsAfter(context);
+  }
+  public triggerEnumsAfter(context: Context): void {
+    this.triggerCallbacks(context, "EnumsAfter");
+  }
+
+  public visitUnionsBefore(context: Context): void {
+    this.triggerUnionsBefore(context);
+  }
+  public triggerUnionsBefore(context: Context): void {
+    this.triggerCallbacks(context, "UnionsBefore");
+  }
+  public visitUnion(context: Context): void {
+    this.triggerCallbacks(context, "Union");
+  }
+  public triggerUnion(context: Context): void {
+    this.triggerCallbacks(context, "Union");
+  }
+  public visitUnionsAfter(context: Context): void {
+    this.triggerUnionsAfter(context);
+  }
+  public triggerUnionsAfter(context: Context): void {
+    this.triggerCallbacks(context, "UnionsAfter");
+  }
+
+  public visitAnnotationsBefore(context: Context): void {
+    this.triggerAnnotationsBefore(context);
+  }
+  public triggerAnnotationsBefore(context: Context): void {
+    this.triggerCallbacks(context, "AnnotationsBefore");
+  }
+  public visitAnnotationBefore(context: Context): void {
+    this.triggerAnnotationBefore(context);
+  }
+  public triggerAnnotationBefore(context: Context): void {
+    this.triggerCallbacks(context, "AnnotationBefore");
+  }
+  public visitAnnotation(context: Context): void {
+    this.triggerAnnotation(context);
+  }
+  public triggerAnnotation(context: Context): void {
+    this.triggerCallbacks(context, "Annotation");
+  }
+
+  public visitAnnotationArgumentsBefore(context: Context): void {
+    this.triggerAnnotationArgumentsBefore(context);
+  }
+  public triggerAnnotationArgumentsBefore(context: Context): void {
+    this.triggerCallbacks(context, "AnnotationArgumentsBefore");
+  }
+  public visitAnnotationArgument(context: Context): void {
+    this.triggerAnnotationArgument(context);
+  }
+  public triggerAnnotationArgument(context: Context): void {
+    this.triggerCallbacks(context, "AnnotationArgument");
+  }
+  public visitAnnotationArgumentsAfter(context: Context): void {
+    this.triggerAnnotationArgumentsAfter(context);
+  }
+  public triggerAnnotationArgumentsAfter(context: Context): void {
+    this.triggerCallbacks(context, "AnnotationArgumentsAfter");
+  }
+  public visitAnnotationAfter(context: Context): void {
+    this.triggerAnnotationAfter(context);
+  }
+  public triggerAnnotationAfter(context: Context): void {
+    this.triggerCallbacks(context, "AnnotationAfter");
+  }
+  public visitAnnotationsAfter(context: Context): void {
+    this.triggerAnnotationsAfter(context);
+  }
+  public triggerAnnotationsAfter(context: Context): void {
+    this.triggerCallbacks(context, "AnnotationsAfter");
+  }
+}
+
+export class BaseVisitor extends AbstractVisitor {
+  writer: Writer;
+
+  constructor(writer: Writer) {
+    super();
+    this.writer = writer;
+  }
+
+  protected write(code: string): void {
+    this.writer.write(code);
+  }
+}
+
+export class MultiVisitor extends AbstractVisitor {
+  private visitors: Visitor[];
+
+  constructor(...visitors: Visitor[]) {
+    super();
+    this.visitors = new Array<Visitor>();
+    this.visitors.push(...visitors);
+  }
+
+  addVisitors(...visitors: Visitor[]): void {
+    this.visitors.push(...visitors);
+  }
+
+  public visitNamespaceBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitNamespaceBefore(context);
+    });
+  }
+  public visitNamespace(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitNamespace(context);
+    });
+  }
+  public visitNamespaceAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitNamespaceAfter(context);
+    });
+  }
+  public visitImportsBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitImportsBefore(context);
+    });
+  }
+  public visitImport(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitImport(context);
+    });
+  }
+  public visitImportsAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitImportsAfter(context);
+    });
+  }
+
+  public visitDirectivesBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitDirectivesBefore(context);
+    });
+  }
+  public visitDirectiveBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitDirectiveBefore(context);
+    });
+  }
+  public visitDirective(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitDirective(context);
+    });
+  }
+  public visitDirectiveParametersBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitDirectiveParametersBefore(context);
+    });
+  }
+  public visitDirectiveParameter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitDirectiveParameter(context);
+    });
+  }
+  public visitDirectiveParametersAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitDirectiveParametersAfter(context);
+    });
+  }
+  public visitDirectiveAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitDirectiveAfter(context);
+    });
+  }
+  public visitDirectivesAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitDirectivesAfter(context);
+    });
+  }
+
+  public visitAliasesBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitAliasesBefore(context);
+    });
+  }
+  public visitAliasBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitAliasBefore(context);
+    });
+  }
+  public visitAlias(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitAlias(context);
+    });
+  }
+  public visitAliasAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitAliasAfter(context);
+    });
+  }
+  public visitAliasesAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitAliasesAfter(context);
+    });
+  }
+
+  public visitAllOperationsBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitAllOperationsBefore(context);
+    });
+  }
+  public visitInterfacesBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitInterfacesBefore(context);
+    });
+  }
+  public visitInterfaceBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitInterfaceBefore(context);
+    });
+  }
+  public visitInterface(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitInterface(context);
+    });
+  }
+  public visitOperationsBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitOperationsBefore(context);
+    });
+  }
+  public visitOperationBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitOperationBefore(context);
+    });
+  }
+  public visitOperation(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitOperation(context);
+    });
+  }
+  public visitParametersBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitParametersBefore(context);
+    });
+  }
+  public visitParameter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitParameter(context);
+    });
+  }
+  public visitParametersAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitParametersAfter(context);
+    });
+  }
+  public visitOperationAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitOperationAfter(context);
+    });
+  }
+  public visitOperationsAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitOperationsAfter(context);
+    });
+  }
+  public visitInterfaceAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitInterfaceAfter(context);
+    });
+  }
+  public visitInterfacesAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitInterfacesAfter(context);
+    });
+  }
+  public visitAllOperationsAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitAllOperationsAfter(context);
+    });
+  }
+
+  public visitTypesBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitTypesBefore(context);
+    });
+  }
+  public visitTypeBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitTypeBefore(context);
+    });
+  }
+  public visitType(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitType(context);
+    });
+  }
+  public visitTypeFieldsBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitTypeFieldsBefore(context);
+    });
+  }
+  public visitTypeField(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitTypeField(context);
+    });
+  }
+  public visitTypeFieldsAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitTypeFieldsAfter(context);
+    });
+  }
+  public visitTypeAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitTypeAfter(context);
+    });
+  }
+  public visitTypesAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitTypesAfter(context);
+    });
+  }
+
+  public visitEnumsBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitEnumsAfter(context);
+    });
+  }
+  public visitEnum(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitEnum(context);
+    });
+  }
+  public visitEnumValuesBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitEnumValuesBefore(context);
+    });
+  }
+  public visitEnumValue(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitEnumValue(context);
+    });
+  }
+  public visitEnumValuesAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitEnumValuesAfter(context);
+    });
+  }
+  public visitEnumsAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitEnumsAfter(context);
+    });
+  }
+
+  public visitUnionsBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitUnionsBefore(context);
+    });
+  }
+  public visitUnion(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitUnion(context);
+    });
+  }
+
+  public visitUnionsAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitUnionsAfter(context);
+    });
+  }
+
+  public visitAnnotationsBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitAnnotationsBefore(context);
+    });
+  }
+  public visitAnnotation(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitAnnotation(context);
+    });
+  }
+  public visitAnnotationArgumentsBefore(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitAnnotationArgumentsBefore(context);
+    });
+  }
+  public visitAnnotationArgument(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitAnnotationArgument(context);
+    });
+  }
+  public visitAnnotationArgumentsAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitAnnotationArgumentsAfter(context);
+    });
+  }
+  public visitAnnotationsAfter(context: Context): void {
+    this.visitors.map((visitor) => {
+      visitor.visitAnnotationsAfter(context);
+    });
+  }
+}

--- a/deno_dist/parser.ts
+++ b/deno_dist/parser.ts
@@ -1,0 +1,1255 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { TokenKind } from "./token_kind.ts";
+import { Lexer, getTokenDesc, getTokenKindDesc } from "./lexer.ts";
+import { importError, syntaxError, ApexError } from "./error/index.ts";
+import autoBind from "./auto-bind.ts";
+import {
+  Location,
+  Token,
+  Name,
+  Document,
+  OperationDefinition,
+  FieldDefinition,
+  ObjectField,
+  Argument,
+  Value,
+  BooleanValue,
+  EnumValue,
+  EnumValueDefinition,
+  FloatValue,
+  ParameterDefinition,
+  IntValue,
+  ListValue,
+  ObjectValue,
+  StringValue,
+  Type,
+  ListType,
+  MapType,
+  Annotation,
+  Named,
+  Node,
+  NamespaceDefinition,
+  ImportDefinition,
+  TypeDefinition,
+  AliasDefinition,
+  InterfaceDefinition,
+  UnionDefinition,
+  EnumDefinition,
+  DirectiveDefinition,
+  Optional,
+  Source,
+  DirectiveRequire,
+  Definition,
+  ImportName,
+  Kind,
+  Stream,
+} from "./ast/index.ts";
+
+type parseFunction = () => Node;
+/**
+ * Configuration options to control parser behavior
+ */
+export type ParseOptions = {
+  /**
+   * By default, the parser creates AST nodes that know the location
+   * in the source that they correspond to. This configuration flag
+   * disables that behavior for performance or testing.
+   */
+  noLocation: boolean;
+
+  noSource: boolean;
+};
+
+/**
+ * Resolver returns the contents of an import.
+ */
+export type Resolver = (location: string, from: string) => string;
+
+/**
+ * Given a Apex source, parses it into a Document.
+ * Throws ApexError if a syntax error is encountered.
+ */
+export function parse(
+  source: string,
+  resolver?: Resolver,
+  options?: ParseOptions
+): Document {
+  const parser = new Parser(source, resolver, options);
+  return parser.parseDocument();
+}
+
+/**
+ * Given a string containing a Apex value (ex. `[42]`), parse the AST for
+ * that value.
+ * Throws ApexError if a syntax error is encountered.
+ *
+ * This is useful within tools that operate upon Apex Values directly and
+ * in isolation of complete Apex documents.
+ *
+ * Consider providing the results to the utility function: valueFromAST().
+ */
+export function parseValue(source: string, options?: ParseOptions): Value {
+  const parser = new Parser(source, undefined, options);
+  parser.expectToken(TokenKind.SOF);
+  const value = parser.parseValueLiteral(false);
+  parser.expectToken(TokenKind.EOF);
+  return value;
+}
+
+export function parseType(source: string, options?: ParseOptions): Type {
+  const parser = new Parser(source, undefined, options);
+  parser.expectToken(TokenKind.SOF);
+  const value = parser.parseType();
+  parser.expectToken(TokenKind.EOF);
+  return value;
+}
+
+interface NamedDefinition {
+  name: Name;
+}
+
+class Parser {
+  _resolver: Resolver | undefined;
+  _options: ParseOptions;
+  _lexer: Lexer;
+
+  constructor(source: string, resolver?: Resolver, options?: ParseOptions) {
+    let src = new Source("apex");
+    src.setBody(source);
+    this._resolver = resolver;
+    this._lexer = new Lexer(src);
+    this._options = options || {
+      noLocation: false,
+      noSource: false,
+    };
+    autoBind(this);
+  }
+
+  /**
+   * Converts a name lex token into a name parse node.
+   */
+  parseName(): Name {
+    const token = this.expectToken(TokenKind.NAME);
+    return new Name(this.loc(token), token.value);
+  }
+
+  parseImportName(): ImportName {
+    const start = this._lexer.token;
+    const name = this.parseName();
+    let alias: Name | undefined;
+    if (this.expectOptionalKeyword("as")) {
+      alias = this.parseName();
+    }
+    return new ImportName(this.loc(start), name, alias);
+  }
+
+  // Implements the parsing rules in the Document section.
+
+  /**
+   * Document : Definition+
+   */
+  parseDocument(): Document {
+    const start = this._lexer.token;
+    //const def = this.many(TokenKind.SOF, this.parseDefinition, TokenKind.EOF);
+    this.expectToken(TokenKind.SOF);
+    const defs = [];
+    do {
+      const def = this.parseDefinition();
+      // Handle resolving imports
+      if (this._resolver != undefined && def.isKind(Kind.ImportDefinition)) {
+        const imp = def as ImportDefinition;
+        let importSource = "";
+        try {
+          importSource = this._resolver!(imp.from.value, "");
+        } catch (e) {
+          throw importError(imp.from, `could not load ${imp.from.value}: ` + e);
+        }
+        const importDoc = parse(importSource, this._resolver, this._options);
+        if (imp.all) {
+          importDoc.definitions.map((def) => {
+            def.imported = true;
+            defs.push(def);
+          });
+        } else {
+          const allDefs = new Map<string, Definition>();
+          importDoc.definitions.map((def) => {
+            switch (def.getKind()) {
+              case Kind.TypeDefinition:
+                const type = def as TypeDefinition;
+                allDefs.set(type.name.value, type);
+                break;
+              case Kind.EnumDefinition:
+                const enumDef = def as EnumDefinition;
+                allDefs.set(enumDef.name.value, enumDef);
+                break;
+              case Kind.UnionDefinition:
+                const unionDef = def as UnionDefinition;
+                allDefs.set(unionDef.name.value, unionDef);
+                break;
+              case Kind.DirectiveDefinition:
+                const directive = def as DirectiveDefinition;
+                allDefs.set(directive.name.value, directive);
+                break;
+              case Kind.AliasDefinition:
+                const alias = def as AliasDefinition;
+                allDefs.set(alias.name.value, alias);
+                break;
+            }
+          });
+
+          imp.names.map((n) => {
+            const def = allDefs.get(n.name.value);
+            if (def == undefined) {
+              throw importError(
+                n,
+                `could not find "${n.name.value}" in "${imp.from.value}"`
+              );
+            }
+            const name = n.alias || n.name;
+            switch (def.getKind()) {
+              case Kind.TypeDefinition:
+                const type = def as TypeDefinition;
+                const renamedType = new TypeDefinition(
+                  name.loc,
+                  name,
+                  type.description,
+                  type.interfaces,
+                  type.annotations,
+                  type.fields
+                );
+                renamedType.imported = true;
+                defs.push(renamedType);
+                break;
+              case Kind.EnumDefinition:
+                const enumDef = def as EnumDefinition;
+                const renamedEnum = new EnumDefinition(
+                  name.loc,
+                  name,
+                  enumDef.description,
+                  enumDef.annotations,
+                  enumDef.values
+                );
+                renamedEnum.imported = true;
+                defs.push(renamedEnum);
+                break;
+              case Kind.UnionDefinition:
+                const unionDef = def as UnionDefinition;
+                const renamedUnion = new UnionDefinition(
+                  name.loc,
+                  name,
+                  unionDef.description,
+                  unionDef.annotations,
+                  unionDef.types
+                );
+                renamedUnion.imported = true;
+                defs.push(renamedUnion);
+                break;
+              case Kind.DirectiveDefinition:
+                const directive = def as DirectiveDefinition;
+                const renamedDirective = new DirectiveDefinition(
+                  name.loc,
+                  name,
+                  directive.description,
+                  directive.parameters,
+                  directive.locations,
+                  directive.requires
+                );
+                renamedDirective.imported = true;
+                defs.push(renamedDirective);
+                break;
+              case Kind.AliasDefinition:
+                const alias = def as AliasDefinition;
+                const renamedAlias = new AliasDefinition(
+                  name.loc,
+                  name,
+                  alias.description,
+                  alias.type,
+                  alias.annotations
+                );
+                renamedAlias.imported = true;
+                defs.push(renamedAlias);
+                break;
+            }
+          });
+        }
+      }
+      defs.push(def);
+    } while (!this.expectOptionalToken(TokenKind.EOF));
+    return new Document(this.loc(start), defs);
+  }
+
+  /**
+   * Definition :
+   *   - ExecutableDefinition
+   *   - TypeSystemDefinition
+   *   - TypeSystemExtension
+   *
+   * ExecutableDefinition :
+   *   - OperationDefinition
+   *   - FragmentDefinition
+   */
+  parseDefinition(): Definition {
+    if (this.peek(TokenKind.NAME)) {
+      switch (this._lexer.token.value) {
+        case "namespace":
+        case "import":
+        case "directive":
+        case "alias":
+        case "interface":
+        case "func":
+        case "type":
+        case "union":
+        case "enum":
+          return this.parseTypeSystemDefinition();
+      }
+    } else if (this.peek(TokenKind.BRACE_L)) {
+      return this.parseOperationDefinition();
+    } else if (this.peekDescription()) {
+      return this.parseTypeSystemDefinition();
+    }
+
+    throw this.unexpected();
+  }
+
+  // Implements the parsing rules in the Operations section.
+
+  /**
+   * OperationDefinition :
+   *  - SelectionSet
+   *  - OperationType Name? VariableDefinitions? Directives? SelectionSet
+   */
+  parseOperationDefinition(): OperationDefinition {
+    const start = this._lexer.token;
+    const description = this.parseDescription();
+    const name = this.parseName();
+    return this.parseOperationDefinitionBody(start, name, description);
+  }
+
+  private parseOperationDefinitionBody(
+    start: Token,
+    name: Name,
+    description: StringValue | undefined
+  ) {
+    const [parameters, isUnary] = this.parseParameterDefinitions(true);
+    const colon = this.expectOptionalToken(TokenKind.COLON);
+    let type: Type = new Named(undefined, new Name(undefined, "void"));
+    if (colon) {
+      const streamLoc = this.loc(this._lexer.token);
+      const stream = this.expectOptionalKeyword("stream");
+      type = this.parseType();
+      if (stream) {
+        const streamLoc = this.loc(this._lexer.token);
+        type = new Stream(streamLoc, type);
+      }
+    }
+    const annotations = this.parseAnnotations();
+
+    return new OperationDefinition(
+      this.loc(start),
+      name,
+      description,
+      type,
+      annotations,
+      isUnary,
+      parameters
+    );
+  }
+
+  /**
+   * Type :
+   *   - NamedType
+   *   - ListType
+   *   - NonNullType
+   */
+  parseType(): Type {
+    const start = this._lexer.token;
+    var keyType: Type | undefined;
+    var valueType: Type | undefined;
+    var ttype: Type | undefined;
+    // [ String? ]?
+    switch (start.kind) {
+      case TokenKind.BRACKET_L:
+        this._lexer.advance();
+        ttype = this.parseType();
+      case TokenKind.BRACKET_R:
+        this._lexer.advance();
+        ttype = new ListType(this.loc(start), ttype!);
+        break;
+      case TokenKind.BRACE_L:
+        this._lexer.advance();
+        keyType = this.parseType();
+        this.expectToken(TokenKind.COLON);
+        valueType = this.parseType();
+      case TokenKind.BRACE_R:
+        this._lexer.advance();
+        ttype = new MapType(this.loc(start), keyType!, valueType!);
+        break;
+      case TokenKind.NAME:
+        ttype = this.parseNamed();
+        break;
+    }
+
+    // QUESTION must be executed
+    const skp = this.expectOptionalToken(TokenKind.QUESTION);
+    if (skp) {
+      ttype = new Optional(this.loc(skp), ttype!);
+    }
+    return ttype!;
+  }
+
+  /**
+   * Arguments[Const] : ( Argument[?Const]+ )
+   */
+  parseArguments(): Array<Argument> {
+    const item = this.parseArgument;
+    return this.optionalMany(TokenKind.PAREN_L, item, TokenKind.PAREN_R);
+  }
+
+  /**
+   * Argument[Const] : Name : Value[?Const]
+   */
+  parseArgument(): Argument {
+    const start = this._lexer.token;
+
+    var name: Name;
+    if (!this.peek(TokenKind.NAME)) {
+      name = new Name(undefined, "value");
+    } else {
+      name = this.parseName();
+      this.expectToken(TokenKind.COLON);
+    }
+
+    return new Argument(this.loc(start), name, this.parseValueLiteral(false));
+  }
+
+  // Implements the parsing rules in the Values section.
+
+  /**
+   * Value[Const] :
+   *   - [~Const] Variable
+   *   - IntValue
+   *   - FloatValue
+   *   - StringValue
+   *   - BooleanValue
+   *   - NullValue
+   *   - EnumValue
+   *   - ListValue[?Const]
+   *   - ObjectValue[?Const]
+   *
+   * BooleanValue : one of `true` `false`
+   *
+   * NullValue : `null`
+   *
+   * EnumValue : Name but not `true`, `false` or `null`
+   */
+  parseValueLiteral(isConst: boolean): Value {
+    const token = this._lexer.token;
+    switch (token.kind) {
+      case TokenKind.BRACKET_L:
+        return this.parseList(isConst);
+      case TokenKind.BRACE_L:
+        return this.parseObject(isConst);
+      case TokenKind.INT:
+        this._lexer.advance();
+        return new IntValue(this.loc(token), parseInt(token.value));
+      case TokenKind.FLOAT:
+        this._lexer.advance();
+        return new FloatValue(this.loc(token), parseFloat(token.value));
+      case TokenKind.STRING:
+      case TokenKind.BLOCK_STRING:
+        return this.parseStringLiteral();
+      case TokenKind.NAME:
+        this._lexer.advance();
+        switch (token.value) {
+          case "true":
+            return new BooleanValue(this.loc(token), true);
+          case "false":
+            return new BooleanValue(this.loc(token), false);
+          case "null":
+          // TODO
+          default:
+            return new EnumValue(this.loc(token), token.value);
+        }
+    }
+    throw this.unexpected();
+  }
+
+  parseConstValue(): Value {
+    return this.parseValueLiteral(true);
+  }
+
+  parseValueValue(): Value {
+    return this.parseValueLiteral(false);
+  }
+
+  parseStringLiteral(): StringValue {
+    const token = this._lexer.token;
+    this._lexer.advance();
+    return new StringValue(this.loc(token), token.value);
+  }
+
+  /**
+   * ListValue[Const] :
+   *   - [ ]
+   *   - [ Value[?Const]+ ]
+   */
+  parseList(isConst: boolean): ListValue {
+    const start = this._lexer.token;
+    const item = () => this.parseValueLiteral(isConst);
+    return new ListValue(
+      this.loc(start),
+      this.any(TokenKind.BRACKET_L, item, TokenKind.BRACKET_R)
+    );
+  }
+
+  /**
+   * ObjectValue[Const] :
+   *   - { }
+   *   - { ObjectField[?Const]+ }
+   */
+  parseObject(isConst: boolean): ObjectValue {
+    const start = this._lexer.token;
+    const item = () => this.parseObjectField(isConst);
+    return new ObjectValue(
+      this.loc(start),
+      this.any(TokenKind.BRACE_L, item, TokenKind.BRACE_R)
+    );
+  }
+
+  /**
+   * ObjectField[Const] : Name : Value[?Const]
+   */
+  parseObjectField(isConst: boolean): ObjectField {
+    const start = this._lexer.token;
+    if (
+      start.kind == TokenKind.NS ||
+      start.kind == TokenKind.NAME ||
+      start.kind == TokenKind.STRING
+    ) {
+      this._lexer.advance();
+    } else {
+      throw this.unexpected();
+    }
+
+    const name = new Name(this.loc(start), start.value);
+    this.expectToken(TokenKind.COLON);
+    return new ObjectField(
+      this.loc(start),
+      name,
+      this.parseValueLiteral(isConst)
+    );
+  }
+
+  parseAnnotations(): Array<Annotation> {
+    let directives = Array<Annotation>();
+    while (this.peek(TokenKind.AT)) {
+      this._lexer.advance();
+      directives.push(this.parseAnnotation());
+    }
+    return directives;
+  }
+
+  parseAnnotation(): Annotation {
+    const start = this._lexer.token;
+    const name = this.parseName();
+    const args = this.parseArguments();
+    return new Annotation(this.loc(start), name, args);
+  }
+
+  // Implements the parsing rules in the Types section.
+
+  /**
+   * NamedType : Name
+   */
+  parseNamed(): Named {
+    const start = this._lexer.token;
+    return new Named(this.loc(start), this.parseName());
+  }
+
+  // Implements the parsing rules in the Type Definition section.
+
+  /**
+   * TypeSystemDefinition :
+   *   - SchemaDefinition
+   *   - TypeDefinition
+   *   - DirectiveDefinition
+   *
+   * TypeDefinition :
+   *   - ScalarTypeDefinition
+   *   - ObjectTypeDefinition
+   *   - InterfaceTypeDefinition
+   *   - UnionTypeDefinition
+   *   - EnumTypeDefinition
+   *   - InputObjectTypeDefinition
+   */
+  parseTypeSystemDefinition(): Definition {
+    // Many definitions begin with a description and require a lookahead.
+    const keywordToken = this.peekDescription()
+      ? this._lexer.lookahead()
+      : this._lexer.token;
+
+    if (keywordToken.kind === TokenKind.NAME) {
+      switch (keywordToken.value) {
+        case String.fromCharCode(TokenKind.STRING):
+          return this.parseTypeSystemDefinition();
+        case String.fromCharCode(TokenKind.BLOCK_STRING):
+          return this.parseTypeSystemDefinition();
+        case String.fromCharCode(TokenKind.NAME):
+          return this.parseTypeSystemDefinition();
+        case "namespace":
+          return this.parseNamespaceDefinition();
+        case "import":
+          return this.parseImportDefinition();
+        case "directive":
+          return this.parseDirectiveDefinition();
+        case "alias":
+          return this.parseAliasDefinition();
+        case "func":
+          return this.parseFunctionDefinition();
+        case "interface":
+          return this.parseInterfaceDefinition();
+        case "type":
+          return this.parseTypeDefinition();
+        case "union":
+          return this.parseUnionDefinition();
+        case "enum":
+          return this.parseEnumDefinition();
+      }
+    }
+
+    throw this.unexpected(keywordToken);
+  }
+
+  parseNamespaceDefinition(): NamespaceDefinition {
+    let start = this._lexer.token;
+    const description = this.parseDescription();
+    this.expectKeyword("namespace");
+
+    start = this._lexer.token;
+    if (
+      start.kind == TokenKind.NS ||
+      start.kind == TokenKind.NAME ||
+      start.kind == TokenKind.STRING
+    ) {
+      this._lexer.advance();
+    } else {
+      throw this.unexpected();
+    }
+
+    const name = new Name(this.loc(start), start.value);
+    const annotations = this.parseAnnotations();
+    return new NamespaceDefinition(
+      this.loc(start),
+      name,
+      description,
+      annotations
+    );
+  }
+
+  parseImportDefinition(): ImportDefinition {
+    let start = this._lexer.token;
+    const description = this.parseDescription();
+    this.expectKeyword("import");
+    let all = false;
+    let names: ImportName[] = [];
+
+    if (this.peek(TokenKind.STAR)) {
+      this._lexer.advance();
+      all = true;
+    } else if (this.peek(TokenKind.BRACE_L)) {
+      names = this.many(
+        TokenKind.BRACE_L,
+        this.parseImportName,
+        TokenKind.BRACE_R
+      );
+    } else {
+      throw this.unexpected();
+    }
+
+    this.expectKeyword("from");
+
+    const from = this.parseStringLiteral();
+    const annotations = this.parseAnnotations();
+    return new ImportDefinition(
+      this.loc(start),
+      description,
+      all,
+      names,
+      from,
+      annotations
+    );
+  }
+
+  parseAliasDefinition(): AliasDefinition {
+    let start = this._lexer.token;
+    const description = this.parseDescription();
+    this.expectKeyword("alias");
+
+    start = this._lexer.token;
+    if (
+      start.kind == TokenKind.NS ||
+      start.kind == TokenKind.NAME ||
+      start.kind == TokenKind.STRING
+    ) {
+      this._lexer.advance();
+    } else {
+      throw this.unexpected();
+    }
+
+    const name = new Name(this.loc(start), start.value);
+    this.expectToken(TokenKind.EQUALS);
+    const type = this.parseType();
+    const annotations = this.parseAnnotations();
+    return new AliasDefinition(
+      this.loc(start),
+      name,
+      description,
+      type,
+      annotations
+    );
+  }
+
+  peekDescription(): boolean {
+    return this.peek(TokenKind.STRING) || this.peek(TokenKind.BLOCK_STRING);
+  }
+
+  /**
+   * Description : StringValue
+   */
+  parseDescription(): StringValue | undefined {
+    if (this.peekDescription()) {
+      return this.parseStringLiteral();
+    }
+    return undefined;
+  }
+
+  /**
+   * TypeDefinition :
+   *   Description?
+   *   type Name ImplementsInterfaces? Annotations[Const]? FieldsDefinition?
+   */
+  parseTypeDefinition(): TypeDefinition {
+    const start = this._lexer.token;
+    const description = this.parseDescription();
+    this.expectKeyword("type");
+    const name = this.parseName();
+    const interfaces = this.parseImplementsInterfaces();
+    const annotations = this.parseAnnotations();
+    const iFields = this.reverse(
+      TokenKind.BRACE_L,
+      this.parseFieldDefinition,
+      TokenKind.BRACE_R,
+      false
+    );
+    return new TypeDefinition(
+      this.loc(start),
+      name,
+      description,
+      interfaces,
+      annotations,
+      iFields as Array<FieldDefinition>
+    );
+  }
+
+  /**
+   * ImplementsInterfaces :
+   *   - implements `&`? NamedType
+   *   - ImplementsInterfaces & NamedType
+   */
+  parseImplementsInterfaces(): Array<Named> {
+    const types = [];
+    if (this.expectOptionalKeyword("implements")) {
+      // Optional leading ampersand
+      this.expectOptionalToken(TokenKind.AMP);
+      do {
+        types.push(this.parseNamed());
+      } while (this.expectOptionalToken(TokenKind.AMP));
+    }
+    return types;
+  }
+
+  /**
+   * FieldDefinition :
+   *   - Description? Name ArgumentsDefinition? : Type Annotations[Const]?
+   */
+  parseFieldDefinition(): FieldDefinition {
+    const start = this._lexer.token;
+    const description = this.parseDescription();
+    const name = this.parseName();
+    this.expectToken(TokenKind.COLON);
+    const type = this.parseType();
+    let defVal: Value | undefined;
+    if (this.expectOptionalToken(TokenKind.EQUALS)) {
+      defVal = this.parseValueLiteral(true);
+    }
+    const annotations = this.parseAnnotations();
+
+    return new FieldDefinition(
+      this.loc(start),
+      name,
+      description,
+      type,
+      defVal,
+      annotations
+    );
+  }
+
+  /**
+   * ParameterDefinition : ( InputValueDefinition+ )
+   */
+  parseParameterDefinitions(
+    unary: boolean
+  ): [Array<ParameterDefinition>, boolean] {
+    if (this.peek(TokenKind.PAREN_L)) {
+      // arguments operation
+      const inputValDefs = this.reverse(
+        TokenKind.PAREN_L,
+        this.parseParameterDefinition,
+        TokenKind.PAREN_R,
+        true
+      );
+      return [inputValDefs as Array<ParameterDefinition>, false];
+    } else if (unary && this.peek(TokenKind.BRACKET_L)) {
+      // unary
+      this._lexer.advance();
+      const inputValueDef = this.parseParameterDefinition();
+      this.expectToken(TokenKind.BRACKET_R);
+      const arr = new Array<ParameterDefinition>();
+      arr.push(inputValueDef);
+      return [arr, true];
+    }
+    //this._lexer.advance();
+    throw new Error(
+      "for Argument Definitions, expect a ( or [ got " +
+        getTokenDesc(this._lexer.token)
+    );
+  }
+
+  /**
+   * ParameterDefinition :
+   *   - Description? Name : Type DefaultValue? Annotations[Const]?
+   */
+  parseParameterDefinition(): ParameterDefinition {
+    const start = this._lexer.token;
+    const description = this.parseDescription();
+    const name = this.parseName();
+    this.expectToken(TokenKind.COLON);
+    const streamLoc = this.loc(this._lexer.token);
+    const stream = this.expectOptionalKeyword("stream");
+    var type = this.parseType();
+    if (stream) {
+      type = new Stream(streamLoc, type);
+    }
+    let defaultValue: Value | undefined;
+    if (this.expectOptionalToken(TokenKind.EQUALS)) {
+      defaultValue = this.parseConstValue();
+    }
+    const annotations = this.parseAnnotations();
+    return new ParameterDefinition(
+      this.loc(start),
+      name,
+      description,
+      type,
+      defaultValue,
+      annotations
+    );
+  }
+
+  reverse(
+    openKind: number,
+    parseFn: parseFunction,
+    closeKind: number,
+    zinteger: boolean
+  ): Array<Node> {
+    this.expectToken(openKind);
+    var nodeArr = [];
+    while (true) {
+      if (this.expectOptionalToken(closeKind)) {
+        break;
+      } else {
+        nodeArr.push(parseFn());
+      }
+    }
+    // if (zinteger && NodeList.length == 0) {
+    //   null; // TODO
+    // }
+    return nodeArr;
+  }
+
+  parseFunctionDefinition(): OperationDefinition {
+    const start = this._lexer.token;
+    const description = this.parseDescription();
+    this.expectKeyword("func");
+    const name = this.parseName();
+    return this.parseOperationDefinitionBody(start, name, description);
+  }
+
+  /**
+   * InterfaceTypeDefinition :
+   *   - Description? interface Name Annotations[Const]? FieldsDefinition?
+   */
+  parseInterfaceDefinition(): InterfaceDefinition {
+    const start = this._lexer.token;
+    const description = this.parseDescription();
+    this.expectKeyword("interface");
+    const name = this.parseName();
+    const annotations = this.parseAnnotations();
+    const iOperations = this.reverse(
+      TokenKind.BRACE_L,
+      this.parseOperationDefinition,
+      TokenKind.BRACE_R,
+      false
+    );
+    return new InterfaceDefinition(
+      this.loc(start),
+      name,
+      description,
+      iOperations as OperationDefinition[],
+      annotations
+    );
+  }
+
+  /**
+   * UnionTypeDefinition :
+   *   - Description? union Name Annotations[Const]? UnionMemberTypes?
+   */
+  parseUnionDefinition(): UnionDefinition {
+    const start = this._lexer.token;
+    const description = this.parseDescription();
+    this.expectKeyword("union");
+    const name = this.parseName();
+    const annotations = this.parseAnnotations();
+    this.expectToken(TokenKind.EQUALS);
+    const types = this.parseUnionMembers();
+    return new UnionDefinition(
+      this.loc(start),
+      name,
+      description,
+      annotations,
+      types
+    );
+  }
+
+  /**
+   * UnionMembers :
+   *   - NamedType
+   *   - UnionMemberTypes | NamedType
+   */
+  parseUnionMembers(): Array<Type> {
+    const types = [];
+    do {
+      const member = this.parseType();
+      types.push(member);
+    } while (this.expectOptionalToken(TokenKind.PIPE));
+    return types;
+  }
+
+  /**
+   * EnumDefinition :
+   *   - Description? enum Name Annotations[Const]? EnumValuesDefinition?
+   */
+  parseEnumDefinition(): EnumDefinition {
+    const start = this._lexer.token;
+    const description = this.parseDescription();
+    this.expectKeyword("enum");
+    const name = this.parseName();
+    const annotations = this.parseAnnotations();
+    const iEnumValueDefs = this.reverse(
+      TokenKind.BRACE_L,
+      this.parseEnumValueDefinition,
+      TokenKind.BRACE_R,
+      false
+    ) as Array<EnumValueDefinition>;
+
+    return new EnumDefinition(
+      this.loc(start),
+      name,
+      description,
+      annotations,
+      iEnumValueDefs
+    );
+  }
+
+  /**
+   * EnumValueDefinition : Description? EnumValue Annotations[Const]?
+   *
+   * EnumValue : Name
+   */
+  parseEnumValueDefinition(): EnumValueDefinition {
+    const start = this._lexer.token;
+    const description = this.parseDescription();
+    const name = this.parseName();
+    this.expectToken(TokenKind.EQUALS);
+
+    const token = this.expectToken(TokenKind.INT);
+    const index = new IntValue(this.loc(token), parseInt(token.value));
+    let display: StringValue | undefined;
+    if (this.expectOptionalKeyword("as")) {
+      display = this.parseStringLiteral();
+    }
+
+    const annotations = this.parseAnnotations();
+    return new EnumValueDefinition(
+      this.loc(start),
+      name,
+      description,
+      index,
+      display,
+      annotations
+    );
+  }
+
+  parseDirectiveDefinition(): DirectiveDefinition {
+    const start = this._lexer.token;
+    const description = this.parseDescription();
+    this.expectKeyword("directive");
+    this.expectToken(TokenKind.AT);
+    const name = this.parseName();
+    const params = this.optionalMany(
+      TokenKind.PAREN_L,
+      this.parseParameterDefinition,
+      TokenKind.PAREN_R
+    );
+    this.expectKeyword("on");
+    const locs = this.parseDirectiveLocations();
+    const reqs: DirectiveRequire[] = [];
+
+    if (this.expectOptionalKeyword("require")) {
+      do {
+        const req = this.parseDirectiveRequire();
+        reqs.push(req);
+      } while (this.peek(TokenKind.AT));
+    }
+
+    return new DirectiveDefinition(
+      this.loc(start),
+      name,
+      description,
+      params,
+      locs,
+      reqs
+    );
+  }
+
+  parseDirectiveRequire(): DirectiveRequire {
+    const start = this._lexer.token;
+    this.expectToken(TokenKind.AT);
+    const name = this.parseName();
+    this.expectKeyword("on");
+    const locations = this.parseDirectiveLocations();
+    return new DirectiveRequire(this.loc(start), name, locations);
+  }
+
+  /**
+   * DirectiveLocations :
+   *   - `|`? DirectiveLocation
+   *   - DirectiveLocations | DirectiveLocation
+   */
+  parseDirectiveLocations(): Array<Name> {
+    // Optional leading pipe
+    this.expectOptionalToken(TokenKind.PIPE);
+    const locations = [];
+    do {
+      locations.push(this.parseDirectiveLocation());
+    } while (this.expectOptionalToken(TokenKind.PIPE));
+    return locations as Array<Name>;
+  }
+
+  /*
+   * DirectiveLocation :
+   *   - ExecutableDirectiveLocation
+   *   - TypeSystemDirectiveLocation
+   *
+   * ExecutableDirectiveLocation : one of
+   *   `QUERY`
+   *   `MUTATION`
+   *   `SUBSCRIPTION`
+   *   `FIELD`
+   *   `FRAGMENT_DEFINITION`
+   *   `FRAGMENT_SPREAD`
+   *   `INLINE_FRAGMENT`
+   *
+   * TypeSystemDirectiveLocation : one of
+   *   `SCHEMA`
+   *   `SCALAR`
+   *   `OBJECT`
+   *   `FIELD_DEFINITION`
+   *   `ARGUMENT_DEFINITION`
+   *   `INTERFACE`
+   *   `UNION`
+   *   `ENUM`
+   *   `ENUM_VALUE`
+   *   `INPUT_OBJECT`
+   *   `INPUT_FIELD_DEFINITION`
+   */
+  parseDirectiveLocation(): Name {
+    const start = this._lexer.token;
+    const name = this.parseName();
+    return name;
+    throw this.unexpected(start);
+  }
+
+  // Core parsing utility functions
+
+  /**
+   * Returns a location object, used to identify the place in
+   * the source that created a given parsed object.
+   */
+  loc(startToken: Token | undefined): Location | undefined {
+    if (startToken == undefined) {
+      return undefined;
+    }
+    if (this._options?.noLocation !== true) {
+      return new Location(startToken.start, startToken.end, this._lexer.source);
+    }
+    return undefined;
+  }
+
+  /**
+   * Determines if the next token is of a given kind
+   */
+  peek(kind: number): boolean {
+    return this._lexer.token.kind === kind;
+  }
+
+  /**
+   * If the next token is of the given kind, return that token after advancing
+   * the lexer. Otherwise, do not change the parser state and throw an error.
+   */
+  expectToken(kind: number): Token {
+    const token = this._lexer.token;
+    if (token.kind === kind) {
+      this._lexer.advance();
+      return token;
+    }
+
+    throw syntaxError(
+      this._lexer.source,
+      token.start,
+      `Expected ${getTokenKindDesc(kind)}, found ${getTokenDesc(token)}.`
+    );
+  }
+
+  /**
+   * If the next token is of the given kind, return that token after advancing
+   * the lexer. Otherwise, do not change the parser state and return undefined.
+   */
+  expectOptionalToken(kind: number): Token | undefined {
+    const token = this._lexer.token;
+    if (token.kind === kind) {
+      this._lexer.advance();
+      return token;
+    }
+    return undefined;
+  }
+
+  /**
+   * If the next token is a given keyword, advance the lexer.
+   * Otherwise, do not change the parser state and throw an error.
+   */
+  expectKeyword(value: string) {
+    const token = this._lexer.token;
+    if (token.kind === TokenKind.NAME && token.value === value) {
+      this._lexer.advance();
+    } else {
+      throw syntaxError(
+        this._lexer.source,
+        token.start,
+        `Expected "${value}", found ${getTokenDesc(token)}.`
+      );
+    }
+  }
+
+  /**
+   * If the next token is a given keyword, return "true" after advancing
+   * the lexer. Otherwise, do not change the parser state and return "false".
+   */
+  expectOptionalKeyword(value: string): boolean {
+    const token = this._lexer.token;
+    if (token.kind === TokenKind.NAME && token.value === value) {
+      this._lexer.advance();
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Helper function for creating an error when an unexpected lexed token
+   * is encountered.
+   */
+  unexpected(atToken?: Token): ApexError {
+    const token = atToken ?? this._lexer.token;
+    return syntaxError(
+      this._lexer.source,
+      token.start,
+      `Unexpected ${getTokenDesc(token)}.`
+    );
+  }
+
+  /**
+   * Returns a possibly empty list of parse nodes, determined by
+   * the parseFn. This list begins with a lex token of openKind
+   * and ends with a lex token of closeKind. Advances the parser
+   * to the next lex token after the closing token.
+   */
+  any<T>(openKind: number, parseFn: () => T, closeKind: number): Array<T> {
+    this.expectToken(openKind);
+    const nodes = [];
+    while (!this.expectOptionalToken(closeKind)) {
+      nodes.push(parseFn.call(this));
+    }
+    return nodes;
+  }
+
+  /**
+   * Returns a list of parse nodes, determined by the parseFn.
+   * It can be empty only if open token is missing otherwise it will always
+   * return non-empty list that begins with a lex token of openKind and ends
+   * with a lex token of closeKind. Advances the parser to the next lex token
+   * after the closing token.
+   */
+  optionalMany<T>(
+    openKind: number,
+    parseFn: () => T,
+    closeKind: number
+  ): Array<T> {
+    if (this.expectOptionalToken(openKind)) {
+      const nodes = [];
+      while (!this.expectOptionalToken(closeKind)) {
+        nodes.push(parseFn.call(this));
+      }
+      return nodes;
+    }
+    return [];
+  }
+
+  /**
+   * Returns a non-empty list of parse nodes, determined by
+   * the parseFn. This list begins with a lex token of openKind
+   * and ends with a lex token of closeKind. Advances the parser
+   * to the next lex token after the closing token.
+   */
+  many<T>(openKind: number, parseFn: () => T, closeKind: number): Array<T> {
+    this.expectToken(openKind);
+    const nodes = [];
+    do {
+      nodes.push(parseFn.call(this));
+    } while (!this.expectOptionalToken(closeKind));
+    return nodes;
+  }
+}

--- a/deno_dist/rules/camel_case_directive_names.ts
+++ b/deno_dist/rules/camel_case_directive_names.ts
@@ -1,0 +1,34 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { AbstractVisitor, Context, Node } from "../ast/index.ts";
+import { validationError } from "../error/index.ts";
+import { camelCase } from "./case.ts";
+
+export class CamelCaseDirectiveNames extends AbstractVisitor {
+  visitDirective(context: Context): void {
+    const directive = context.directive!;
+    const name = directive.name.value;
+    if (name != camelCase(name)) {
+      context.reportError(
+        validationError(
+          directive.name,
+          `directive "${name}" should be camel case`
+        )
+      );
+    }
+  }
+}

--- a/deno_dist/rules/case.ts
+++ b/deno_dist/rules/case.ts
@@ -1,0 +1,173 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// The following functions are from
+// https://github.com/blakeembrey/change-case
+// Pasted here to avoid an NPM dependency for the CLI.
+
+export function camelCaseTransform(input: string, index: number) {
+  if (index === 0) return input.toLowerCase();
+  return pascalCaseTransform(input, index);
+}
+
+export function camelCaseTransformMerge(input: string, index: number) {
+  if (index === 0) return input.toLowerCase();
+  return pascalCaseTransformMerge(input);
+}
+
+export function camelCase(input: string, options: Options = {}) {
+  return pascalCase(input, {
+    transform: camelCaseTransform,
+    ...options,
+  });
+}
+
+export function pascalCaseTransform(input: string, index: number) {
+  const firstChar = input.charAt(0);
+  const lowerChars = input.substr(1).toLowerCase();
+  if (index > 0 && firstChar >= "0" && firstChar <= "9") {
+    return `_${firstChar}${lowerChars}`;
+  }
+  return `${firstChar.toUpperCase()}${lowerChars}`;
+}
+
+export function pascalCaseTransformMerge(input: string) {
+  return input.charAt(0).toUpperCase() + input.slice(1).toLowerCase();
+}
+
+export function pascalCase(input: string, options: Options = {}) {
+  return noCase(input, {
+    delimiter: "",
+    transform: pascalCaseTransform,
+    ...options,
+  });
+}
+
+export function snakeCase(input: string, options: Options = {}) {
+  return dotCase(input, {
+    delimiter: "_",
+    ...options,
+  });
+}
+
+export function dotCase(input: string, options: Options = {}) {
+  return noCase(input, {
+    delimiter: ".",
+    ...options,
+  });
+}
+
+// Support camel case ("camelCase" -> "camel Case" and "CAMELCase" -> "CAMEL Case").
+const DEFAULT_SPLIT_REGEXP = [/([a-z0-9])([A-Z])/g, /([A-Z])([A-Z][a-z])/g];
+
+// Remove all non-word characters.
+const DEFAULT_STRIP_REGEXP = /[^A-Z0-9]+/gi;
+
+export interface Options {
+  splitRegexp?: RegExp | RegExp[];
+  stripRegexp?: RegExp | RegExp[];
+  delimiter?: string;
+  transform?: (part: string, index: number, parts: string[]) => string;
+}
+
+export function noCase(input: string, options: Options = {}) {
+  const {
+    splitRegexp = DEFAULT_SPLIT_REGEXP,
+    stripRegexp = DEFAULT_STRIP_REGEXP,
+    transform = lowerCase,
+    delimiter = " ",
+  } = options;
+
+  let result = replace(
+    replace(input, splitRegexp, "$1\0$2"),
+    stripRegexp,
+    "\0"
+  );
+  let start = 0;
+  let end = result.length;
+
+  // Trim the delimiter from around the output string.
+  while (result.charAt(start) === "\0") start++;
+  while (result.charAt(end - 1) === "\0") end--;
+
+  // Transform each token independently.
+  return result.slice(start, end).split("\0").map(transform).join(delimiter);
+}
+
+/**
+ * Replace `re` in the input string with the replacement value.
+ */
+function replace(input: string, re: RegExp | RegExp[], value: string) {
+  if (re instanceof RegExp) return input.replace(re, value);
+  return re.reduce((input, re) => input.replace(re, value), input);
+}
+
+/**
+ * Locale character mapping rules.
+ */
+interface Locale {
+  regexp: RegExp;
+  map: Record<string, string>;
+}
+
+/**
+ * Source: ftp://ftp.unicode.org/Public/UCD/latest/ucd/SpecialCasing.txt
+ */
+const SUPPORTED_LOCALE: Record<string, Locale> = {
+  tr: {
+    regexp: /\u0130|\u0049|\u0049\u0307/g,
+    map: {
+      İ: "\u0069",
+      I: "\u0131",
+      İ: "\u0069",
+    },
+  },
+  az: {
+    regexp: /\u0130/g,
+    map: {
+      İ: "\u0069",
+      I: "\u0131",
+      İ: "\u0069",
+    },
+  },
+  lt: {
+    regexp: /\u0049|\u004A|\u012E|\u00CC|\u00CD|\u0128/g,
+    map: {
+      I: "\u0069\u0307",
+      J: "\u006A\u0307",
+      Į: "\u012F\u0307",
+      Ì: "\u0069\u0307\u0300",
+      Í: "\u0069\u0307\u0301",
+      Ĩ: "\u0069\u0307\u0303",
+    },
+  },
+};
+
+/**
+ * Localized lower case.
+ */
+export function localeLowerCase(str: string, locale: string) {
+  const lang = SUPPORTED_LOCALE[locale.toLowerCase()];
+  if (lang) return lowerCase(str.replace(lang.regexp, (m) => lang.map[m]));
+  return lowerCase(str);
+}
+
+/**
+ * Lower case as a function.
+ */
+export function lowerCase(str: string) {
+  return str.toLowerCase();
+}

--- a/deno_dist/rules/index.ts
+++ b/deno_dist/rules/index.ts
@@ -1,0 +1,17 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export * from "./rules.ts";

--- a/deno_dist/rules/known_types.ts
+++ b/deno_dist/rules/known_types.ts
@@ -1,0 +1,166 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import {
+  AbstractVisitor,
+  Context,
+  Type,
+  Named,
+  Kind,
+  Optional,
+  MapType,
+  ListType,
+} from "../ast/index.ts";
+import { validationError } from "../error/index.ts";
+
+const builtInTypeNames = new Set([
+  "i8",
+  "u8",
+  "i16",
+  "u16",
+  "i32",
+  "u32",
+  "i64",
+  "u64",
+  "f32",
+  "f64",
+  "bool",
+  "string",
+  "datetime",
+  "bytes",
+  "any",
+  "value",
+]);
+
+export class KnownTypes extends AbstractVisitor {
+  visitAlias(context: Context): void {
+    const alias = context.alias!;
+    this.checkType(context, `alias`, alias.name.value, alias.type);
+  }
+  visitOperationAfter(context: Context): void {
+    const oper = context.operation!;
+    // "void" is a special case for operations without a return.
+    if (
+      oper.type.isKind(Kind.Named) &&
+      (oper.type as Named).name.value == "void"
+    ) {
+      return;
+    }
+    this.checkType(
+      context,
+      `return`,
+      oper.name.value,
+      oper.type // return type
+    );
+  }
+  visitParameter(context: Context): void {
+    const oper = context.operation!;
+    const param = context.parameter!;
+    this.checkType(
+      context,
+      `parameter "${param.name.value}"`,
+      `${oper.name.value}`,
+      param.type
+    );
+  }
+
+  visitTypeField(context: Context): void {
+    const type = context.type!;
+    const field = context.field!;
+    this.checkType(
+      context,
+      `field "${field.name.value}"`,
+      `${type.name.value}`,
+      field.type
+    );
+  }
+
+  visitUnion(context: Context): void {
+    const union = context.union!;
+    union.types.forEach((t) => {
+      this.checkType(
+        context,
+        `union "${union.name.value}"`,
+        `${union.name.value}`,
+        t
+      );
+    });
+  }
+
+  visitDirectiveParameter(context: Context): void {
+    const directive = context.directive!;
+    const param = context.parameter!;
+    this.checkType(
+      context,
+      `parameter "${param.name.value}"`,
+      `${directive.name.value}`,
+      param.type
+    );
+  }
+
+  private checkType(
+    context: Context,
+    forName: string,
+    parentName: string,
+    t: Type
+  ) {
+    switch (t.getKind()) {
+      case Kind.Named:
+        const named = t as Named;
+        const name = named.name.value;
+        var first = name.charAt(0);
+
+        if (first === first.toLowerCase()) {
+          // Check for built-in types
+          if (!builtInTypeNames.has(name)) {
+            context.reportError(
+              validationError(
+                named,
+                `invalid built-in type "${named.name.value}" for ${forName} in "${parentName}"`
+              )
+            );
+          }
+        } else {
+          // Check against defined types
+          if (!context.allTypes.has(name)) {
+            context.reportError(
+              validationError(
+                named,
+                `unknown type "${named.name.value}" for ${forName} in "${parentName}"`
+              )
+            );
+          }
+        }
+        break;
+
+      case Kind.Optional:
+        const optional = t as Optional;
+        this.checkType(context, forName, parentName, optional.type);
+        break;
+
+      case Kind.MapType:
+        const map = t as MapType;
+        this.checkType(context, forName, parentName, map.keyType);
+        this.checkType(context, forName, parentName, map.valueType);
+        break;
+
+      case Kind.ListType:
+        const list = t as ListType;
+        this.checkType(context, forName, parentName, list.type);
+        break;
+    }
+  }
+}

--- a/deno_dist/rules/mod.ts
+++ b/deno_dist/rules/mod.ts
@@ -1,0 +1,17 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export * from "./rules.ts";

--- a/deno_dist/rules/namespace_first.ts
+++ b/deno_dist/rules/namespace_first.ts
@@ -1,0 +1,40 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { AbstractVisitor, Context, Kind, Node } from "../ast/index.ts";
+import { validationError } from "../error/index.ts";
+
+export class NamespaceFirst extends AbstractVisitor {
+  visitNamespace(context: Context): void {
+    var firstNonImportPos = 0;
+    const definitions = context.document!.definitions;
+    for (let i = 0; i < definitions.length; i++) {
+      const def = definitions[i];
+      if (!def.imported && !def.isKind(Kind.ImportDefinition)) {
+        firstNonImportPos = i;
+        break;
+      }
+    }
+    if (context.namespacePos != firstNonImportPos) {
+      context.reportError(
+        validationError(
+          context.namespace,
+          `namespace must be defined before any other definition`
+        )
+      );
+    }
+  }
+}

--- a/deno_dist/rules/pascal_case_type_names.ts
+++ b/deno_dist/rules/pascal_case_type_names.ts
@@ -1,0 +1,62 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { AbstractVisitor, Context } from "../ast/index.ts";
+import { validationError } from "../error/index.ts";
+
+const pascalMatcher = /[A-Z][A-Za-z0-9]*/;
+
+export class PascalCaseTypeNames extends AbstractVisitor {
+  visitAlias(context: Context): void {
+    const alias = context.alias!;
+    const name = alias.name.value;
+    if (!pascalMatcher.test(name)) {
+      context.reportError(
+        validationError(alias.name, `alias "${name}" should be pascal case`)
+      );
+    }
+  }
+
+  visitType(context: Context): void {
+    const type = context.type!;
+    const name = type.name.value;
+    if (!pascalMatcher.test(name)) {
+      context.reportError(
+        validationError(type.name, `type "${name}" should be pascal case`)
+      );
+    }
+  }
+
+  visitEnum(context: Context): void {
+    const enumDef = context.enum!;
+    const name = enumDef.name.value;
+    if (!pascalMatcher.test(name)) {
+      context.reportError(
+        validationError(enumDef.name, `enum "${name}" should be pascal case`)
+      );
+    }
+  }
+
+  visitUnion(context: Context): void {
+    const union = context.union!;
+    const name = union.name.value;
+    if (!pascalMatcher.test(name)) {
+      context.reportError(
+        validationError(union.name, `union "${name}" should be pascal case`)
+      );
+    }
+  }
+}

--- a/deno_dist/rules/rules.ts
+++ b/deno_dist/rules/rules.ts
@@ -1,0 +1,62 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { Visitor } from "../ast/index.ts";
+import { NamespaceFirst } from "./namespace_first.ts";
+import { SingleNamespaceDefined } from "./single_namespace_defined.ts";
+//import { CamelCaseDirectiveNames } from "./camel_case_directive_names.js";
+import { PascalCaseTypeNames } from "./pascal_case_type_names.ts";
+import { UniqueDirectiveNames } from "./unique_directive_names.ts";
+import { UniqueObjectNames } from "./unique_object_names.ts";
+import { UniqueFunctionNames } from "./unique_function_names.ts";
+import { UniqueOperationNames } from "./unique_operation_names.ts";
+import { UniqueParameterNames } from "./unique_parameter_names.ts";
+import { UniqueTypeFieldNames } from "./unique_type_field_names.ts";
+import { UniqueEnumValueNames } from "./unique_enum_value_names.ts";
+import { UniqueEnumValueIndexes } from "./unique_enum_value_indexes.ts";
+import { ValidEnumValueIndexes } from "./valid_enum_value_indexes.ts";
+import { KnownTypes } from "./known_types.ts";
+import { ValidDirectiveParameterTypes } from "./valid_directive_parameter_types.ts";
+import { ValidDirectiveRequires } from "./valid_directive_requires.ts";
+import { ValidDirectiveLocations } from "./valid_directive_locations.ts";
+import { ValidAnnotationArguments } from "./valid_annotation_arguments.ts";
+import { ValidAnnotationLocations } from "./valid_annotation_locations.ts";
+
+export interface ValidationRule {
+  new (): Visitor;
+}
+
+export const CommonRules: Array<ValidationRule> = [
+  NamespaceFirst,
+  SingleNamespaceDefined,
+  //CamelCaseDirectiveNames,
+  PascalCaseTypeNames,
+  UniqueDirectiveNames,
+  UniqueObjectNames,
+  UniqueFunctionNames,
+  UniqueOperationNames,
+  UniqueParameterNames,
+  UniqueTypeFieldNames,
+  UniqueEnumValueNames,
+  UniqueEnumValueIndexes,
+  ValidEnumValueIndexes,
+  KnownTypes,
+  ValidDirectiveParameterTypes,
+  ValidDirectiveRequires,
+  ValidDirectiveLocations,
+  ValidAnnotationArguments,
+  ValidAnnotationLocations,
+];

--- a/deno_dist/rules/single_namespace_defined.ts
+++ b/deno_dist/rules/single_namespace_defined.ts
@@ -1,0 +1,32 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { AbstractVisitor, Context, Node } from "../ast/index.ts";
+import { validationError } from "../error/index.ts";
+
+export class SingleNamespaceDefined extends AbstractVisitor {
+  private found: boolean = false;
+
+  visitNamespace(context: Context): void {
+    if (this.found) {
+      const namespace = context.namespace;
+      context.reportError(
+        validationError(namespace, `only one namespace can be defined`)
+      );
+    }
+    this.found = true;
+  }
+}

--- a/deno_dist/rules/unique_directive_names.ts
+++ b/deno_dist/rules/unique_directive_names.ts
@@ -1,0 +1,34 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { AbstractVisitor, Context } from "../ast/index.ts";
+import { validationError } from "../error/index.ts";
+
+export class UniqueDirectiveNames extends AbstractVisitor {
+  private names: Set<string> = new Set<string>();
+
+  visitDirective(context: Context): void {
+    const dir = context.directive!;
+    const dirName = dir.name.value;
+    if (this.names.has(dirName)) {
+      context.reportError(
+        validationError(dir.name, `duplicate directive "${dirName}"`)
+      );
+    } else {
+      this.names.add(dirName);
+    }
+  }
+}

--- a/deno_dist/rules/unique_enum_value_indexes.ts
+++ b/deno_dist/rules/unique_enum_value_indexes.ts
@@ -1,0 +1,42 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { AbstractVisitor, Context } from "../ast/index.ts";
+import { validationError } from "../error/index.ts";
+
+export class UniqueEnumValueIndexes extends AbstractVisitor {
+  private parentName: string = "";
+  private values: Set<number> = new Set<number>();
+
+  visitEnum(context: Context): void {
+    this.parentName = context.enum!.name.value;
+    this.values = new Set<number>();
+  }
+  visitEnumValue(context: Context): void {
+    const enumValue = context.enumValue!;
+    const value = enumValue.index.value;
+    if (this.values.has(value)) {
+      context.reportError(
+        validationError(
+          enumValue.index,
+          `duplicate value index "${value}" in enum "${this.parentName}"`
+        )
+      );
+    } else {
+      this.values.add(value);
+    }
+  }
+}

--- a/deno_dist/rules/unique_enum_value_names.ts
+++ b/deno_dist/rules/unique_enum_value_names.ts
@@ -1,0 +1,42 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { AbstractVisitor, Context } from "../ast/index.ts";
+import { validationError } from "../error/index.ts";
+
+export class UniqueEnumValueNames extends AbstractVisitor {
+  private parentName: string = "";
+  private names: Set<string> = new Set<string>();
+
+  visitEnum(context: Context): void {
+    this.parentName = context.enum!.name.value;
+    this.names = new Set<string>();
+  }
+  visitEnumValue(context: Context): void {
+    const enumValue = context.enumValue!;
+    const name = enumValue.name.value;
+    if (this.names.has(name)) {
+      context.reportError(
+        validationError(
+          enumValue.name,
+          `duplicate value name "${name}" in enum "${this.parentName}"`
+        )
+      );
+    } else {
+      this.names.add(name);
+    }
+  }
+}

--- a/deno_dist/rules/unique_function_names.ts
+++ b/deno_dist/rules/unique_function_names.ts
@@ -1,0 +1,34 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { AbstractVisitor, Context } from "../ast/index.ts";
+import { validationError } from "../error/index.ts";
+
+export class UniqueFunctionNames extends AbstractVisitor {
+  private operationNames: Set<string> = new Set<string>();
+
+  visitFunction(context: Context): void {
+    const oper = context.operation!;
+    const operName = oper.name.value;
+    if (this.operationNames.has(operName)) {
+      context.reportError(
+        validationError(oper.name, `duplicate function "${operName}"`)
+      );
+    } else {
+      this.operationNames.add(operName);
+    }
+  }
+}

--- a/deno_dist/rules/unique_object_names.ts
+++ b/deno_dist/rules/unique_object_names.ts
@@ -1,0 +1,48 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { AbstractVisitor, Context, Node } from "../ast/index.ts";
+import { validationError } from "../error/index.ts";
+
+export class UniqueObjectNames extends AbstractVisitor {
+  private typeNames: Set<string> = new Set<string>();
+
+  visitNamespace(context: Context): void {
+    this.typeNames = new Set<string>();
+  }
+  visitInterface(context: Context): void {
+    this.check(context, context.interface!.name.value, context.interface!.name);
+  }
+  visitType(context: Context): void {
+    this.check(context, context.type!.name.value, context.type!.name);
+  }
+  visitUnion(context: Context): void {
+    this.check(context, context.union!.name.value, context.union!.name);
+  }
+  visitEnum(context: Context): void {
+    this.check(context, context.enum!.name.value, context.enum!.name);
+  }
+  visitAlias(context: Context): void {
+    this.check(context, context.alias!.name.value, context.alias!.name);
+  }
+  private check(context: Context, name: string, node: Node): void {
+    if (this.typeNames.has(name)) {
+      context.reportError(validationError(node, `duplicate object "${name}"`));
+    } else {
+      this.typeNames.add(name);
+    }
+  }
+}

--- a/deno_dist/rules/unique_operation_names.ts
+++ b/deno_dist/rules/unique_operation_names.ts
@@ -1,0 +1,42 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { AbstractVisitor, Context } from "../ast/index.ts";
+import { validationError } from "../error/index.ts";
+
+export class UniqueOperationNames extends AbstractVisitor {
+  private parentName: string = "";
+  private operationNames: Set<string> = new Set<string>();
+
+  visitInterfaceBefore(context: Context): void {
+    this.parentName = `interface "${context.interface!.name.value}"`;
+    this.operationNames = new Set<string>();
+  }
+  visitOperation(context: Context): void {
+    const oper = context.operation!;
+    const operName = oper.name.value;
+    if (this.operationNames.has(operName)) {
+      context.reportError(
+        validationError(
+          oper.name,
+          `duplicate operation "${operName}" in ${this.parentName}`
+        )
+      );
+    } else {
+      this.operationNames.add(operName);
+    }
+  }
+}

--- a/deno_dist/rules/unique_parameter_names.ts
+++ b/deno_dist/rules/unique_parameter_names.ts
@@ -1,0 +1,49 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { AbstractVisitor, Context } from "../ast/index.ts";
+import { validationError } from "../error/index.ts";
+
+export class UniqueParameterNames extends AbstractVisitor {
+  private parentName: string = "";
+  private paramNames: Set<string> = new Set<string>();
+
+  visitFunctionBefore(context: Context): void {
+    this.parentName = `func "${context.operation!.name.value}"`;
+    this.paramNames = new Set<string>();
+  }
+
+  visitOperationBefore(context: Context): void {
+    this.parentName = `operation "${context.operation!.name.value}"`;
+    this.parentName = context.operation!.name.value;
+    this.paramNames = new Set<string>();
+  }
+
+  visitParameter(context: Context): void {
+    const param = context.parameter!;
+    const paramName = param.name.value;
+    if (this.paramNames.has(paramName)) {
+      context.reportError(
+        validationError(
+          param.name,
+          `duplicate parameter "${paramName}" in ${this.parentName}`
+        )
+      );
+    } else {
+      this.paramNames.add(paramName);
+    }
+  }
+}

--- a/deno_dist/rules/unique_type_field_names.ts
+++ b/deno_dist/rules/unique_type_field_names.ts
@@ -1,0 +1,43 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { AbstractVisitor, Context } from "../ast/index.ts";
+import { validationError } from "../error/index.ts";
+
+export class UniqueTypeFieldNames extends AbstractVisitor {
+  private parentName: string = "";
+  private names: Set<string> = new Set<string>();
+
+  visitTypeBefore(context: Context): void {
+    this.parentName = context.type!.name.value;
+    this.names = new Set<string>();
+  }
+
+  visitTypeField(context: Context): void {
+    const field = context.field!;
+    const fieldName = field.name.value;
+    if (this.names.has(fieldName)) {
+      context.reportError(
+        validationError(
+          field.name,
+          `duplicate field "${fieldName}" in type "${this.parentName}"`
+        )
+      );
+    } else {
+      this.names.add(fieldName);
+    }
+  }
+}

--- a/deno_dist/rules/valid_annotation_arguments.ts
+++ b/deno_dist/rules/valid_annotation_arguments.ts
@@ -1,0 +1,301 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import {
+  AbstractVisitor,
+  Annotation,
+  Argument,
+  Context,
+  Kind,
+  ListType,
+  ListValue,
+  Named,
+  ObjectValue,
+  Type,
+  Value,
+  MapType,
+  Optional,
+  TypeDefinition,
+  EnumDefinition,
+  EnumValue,
+  FieldDefinition,
+  IntValue,
+} from "../ast/index.ts";
+import { validationError } from "../error/index.ts";
+
+const integerBuiltInTypeNames = new Set([
+  "i8",
+  "u8",
+  "i16",
+  "u16",
+  "i32",
+  "u32",
+  "i64",
+  "u64",
+]);
+
+const floatBuiltInTypeNames = new Set(["f32", "f64"]);
+
+export class ValidAnnotationArguments extends AbstractVisitor {
+  visitAnnotation(context: Context): void {
+    const a = context.annotation!;
+
+    const foundArgNames = new Set<string>();
+    a.arguments.forEach((v) => {
+      if (foundArgNames.has(v.name.value)) {
+        context.reportError(
+          validationError(
+            v,
+            `duplicate argument "${v.name.value}" in annotation "${a.name.value}"`
+          )
+        );
+      }
+      foundArgNames.add(v.name.value);
+    });
+
+    const dir = context.directiveMap.get(a.name.value);
+    if (dir == undefined) {
+      return;
+    }
+
+    let args = new Map<string, Argument>();
+    a.arguments.map((arg) => args.set(arg.name.value, arg));
+
+    for (let param of dir.parameters) {
+      const arg = args.get(param.name.value);
+      if (arg == undefined) {
+        if (!param.type.isKind(Kind.Optional)) {
+          context.reportError(
+            validationError(
+              a,
+              `missing required argument "${param.name.value}" in annotation "${a.name.value}"`
+            )
+          );
+        }
+        continue;
+      }
+      args.delete(param.name.value);
+
+      // Validate types
+      this.check(context, param.type, arg.value, a);
+    }
+
+    args.forEach((arg) => {
+      context.reportError(
+        validationError(
+          arg,
+          `unknown parameter "${arg.name.value}" in directive "${dir.name.value}`
+        )
+      );
+    });
+  }
+
+  private check(
+    context: Context,
+    type: Type,
+    value: Value,
+    annotation: Annotation
+  ) {
+    switch (type.getKind()) {
+      case Kind.Optional:
+        const optional = type as Optional;
+        this.check(context, optional.type, value, annotation);
+        break;
+
+      case Kind.Named:
+        const named = type as Named;
+        if (named.name.value == "string") {
+          if (!value.isKind(Kind.StringValue)) {
+            context.reportError(
+              validationError(
+                value,
+                `invalid value "${value.getValue()}" in annotation "${
+                  annotation.name.value
+                }": expected a string`
+              )
+            );
+          }
+        } else if (integerBuiltInTypeNames.has(named.name.value)) {
+          if (!value.isKind(Kind.IntValue)) {
+            context.reportError(
+              validationError(
+                value,
+                `invalid value "${value.getValue()}" in annotation "${
+                  annotation.name.value
+                }": expected a integer`
+              )
+            );
+            return;
+          }
+          const intValue = value as IntValue;
+          if (named.name.value.substring(0, 1) == "u" && intValue.value < 0) {
+            context.reportError(
+              validationError(
+                value,
+                `invalid value "${intValue.value}" in annotation "${annotation.name.value}": expected a non-negative integer`
+              )
+            );
+          }
+        } else if (floatBuiltInTypeNames.has(named.name.value)) {
+          if (!value.isKind(Kind.FloatValue)) {
+            context.reportError(
+              validationError(
+                value,
+                `invalid value "${value.getValue()}" in annotation "${
+                  annotation.name.value
+                }": expected a float`
+              )
+            );
+          }
+        } else if (named.name.value == "bool") {
+          if (!value.isKind(Kind.BooleanValue)) {
+            context.reportError(
+              validationError(
+                value,
+                `invalid value "${value.getValue()}" in annotation "${
+                  annotation.name.value
+                }": expected a boolean`
+              )
+            );
+          }
+        } else {
+          const definition = context.allTypes.get(named.name.value);
+          if (definition == undefined) {
+            // error reported by KnownTypes
+            return;
+          }
+          if (definition.isKind(Kind.EnumDefinition)) {
+            if (!value.isKind(Kind.EnumValue)) {
+              context.reportError(
+                validationError(
+                  value,
+                  `invalid value "${value.getValue()}" in annotation "${
+                    annotation.name.value
+                  }": expected an enum value`
+                )
+              );
+              return;
+            }
+            const expectedEnumValue = value as EnumValue;
+            const enumDef = definition as EnumDefinition;
+            const enumValue = enumDef.values.filter((enumValue) => {
+              return expectedEnumValue.value === enumValue.name.value;
+            });
+            if (enumValue.length < 1) {
+              context.reportError(
+                validationError(
+                  value,
+                  `unknown enum value "${expectedEnumValue.value}" in annotation "${annotation.name.value}": expected value from "${enumDef.name.value}"`
+                )
+              );
+            }
+          } else if (definition.isKind(Kind.TypeDefinition)) {
+            if (!value.isKind(Kind.ObjectValue)) {
+              context.reportError(
+                validationError(
+                  value,
+                  `invalid value "${value.getValue()}" in annotation "${
+                    annotation.name.value
+                  }": expected an object`
+                )
+              );
+              return;
+            }
+            const type = definition as TypeDefinition;
+            const obj = value as ObjectValue;
+
+            let fields = new Map<string, FieldDefinition>();
+            type.fields.map((field) => fields.set(field.name.value, field));
+
+            for (let field of obj.fields) {
+              const f = fields.get(field.name.value);
+              if (f == undefined) {
+                context.reportError(
+                  validationError(
+                    field.name,
+                    `unknown field "${field.name.value}" for type "${type.name.value}" in annotation "${annotation.name.value}"`
+                  )
+                );
+                continue;
+              }
+              fields.delete(field.name.value);
+
+              // Validate types
+              this.check(context, f.type, field.value, annotation);
+            }
+            fields.forEach((field, name) => {
+              if (!field.type.isKind(Kind.Optional)) {
+                context.reportError(
+                  validationError(
+                    obj,
+                    `missing required field "${field.name.value}" for type "${type.name.value}" in annotation "${annotation.name.value}"`
+                  )
+                );
+              }
+            });
+          } else {
+            context.reportError(
+              validationError(
+                value,
+                `invalid value "${value.getValue()}" in annotation "${
+                  annotation.name.value
+                }": expected an object`
+              )
+            );
+          }
+        }
+        break;
+
+      case Kind.ListType:
+        const list = type as ListType;
+        if (!value.isKind(Kind.ListValue)) {
+          context.reportError(
+            validationError(
+              value,
+              `invalid value "${value.getValue()}" in annotation "${
+                annotation.name.value
+              }": expected a list`
+            )
+          );
+          return;
+        }
+        const listValue = value as ListValue;
+        for (let value of listValue.value) {
+          this.check(context, list.type, value, annotation);
+        }
+        break;
+
+      case Kind.MapType:
+        const map = type as MapType;
+        if (!value.isKind(Kind.ObjectValue)) {
+          context.reportError(
+            validationError(
+              value,
+              `invalid value "${value.getValue()}" in annotation "${
+                annotation.name.value
+              }": expected a map`
+            )
+          );
+          return;
+        }
+        const objectValue = value as ObjectValue;
+        for (let field of objectValue.fields) {
+          this.check(context, map.valueType, field.value, annotation);
+        }
+        break;
+    }
+  }
+}

--- a/deno_dist/rules/valid_annotation_locations.ts
+++ b/deno_dist/rules/valid_annotation_locations.ts
@@ -1,0 +1,221 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { AbstractVisitor, Annotation, Context, Kind } from "../ast/index.ts";
+import { validationError } from "../error/index.ts";
+
+export class ValidAnnotationLocations extends AbstractVisitor {
+  visitNamespace(context: Context): void {
+    const def = context.namespace!;
+    this.check(context, def.annotations, "NAMESPACE");
+  }
+
+  visitInterface(context: Context): void {
+    const def = context.interface!;
+    this.check(context, def.annotations, "INTERFACE");
+  }
+
+  visitOperation(context: Context): void {
+    const def = context.operation!;
+    this.check(context, def.annotations, "OPERATION");
+  }
+
+  visitParameter(context: Context): void {
+    const def = context.parameter!;
+    this.check(context, def.annotations, "PARAMETER");
+  }
+
+  visitType(context: Context): void {
+    const def = context.type!;
+    this.check(context, def.annotations, "TYPE");
+  }
+
+  visitTypeField(context: Context): void {
+    const def = context.field!;
+    this.check(context, def.annotations, "FIELD");
+  }
+
+  visitEnum(context: Context): void {
+    const def = context.enum!;
+    this.check(context, def.annotations, "ENUM");
+  }
+
+  visitEnumValue(context: Context): void {
+    const def = context.enumValue!;
+    this.check(context, def.annotations, "ENUM_VALUE");
+  }
+
+  visitUnion(context: Context): void {
+    const def = context.union!;
+    this.check(context, def.annotations, "UNION");
+  }
+
+  visitAlias(context: Context): void {
+    const alias = context.alias!;
+    this.check(context, alias.annotations, "ALIAS");
+  }
+
+  private check(context: Context, annotations: Annotation[], location: string) {
+    for (let annotation of annotations) {
+      this.checkAnnotation(context, annotations, annotation, location);
+    }
+  }
+
+  private checkAnnotation(
+    context: Context,
+    annotations: Annotation[],
+    annotation: Annotation,
+    location: string
+  ) {
+    const dir = context.directiveMap.get(annotation.name.value);
+    if (dir == undefined) {
+      return;
+    }
+    let found = false;
+    for (let loc of dir.locations) {
+      if (loc.value == location) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      context.reportError(
+        validationError(
+          annotation,
+          `annotation "${annotation.name.value}" is not valid on a ${location
+            .toLowerCase()
+            .replace("_", " ")}`
+        )
+      );
+      return;
+    }
+
+    dirRequiresLoop:
+    for (let req of dir.requires) {
+      let found = false;
+      for (let loc of req.locations) {
+        switch (loc.value) {
+          case "SELF":
+            if (findAnnotation(req.directive.value, annotations)) {
+              found = true;
+              break dirRequiresLoop;
+            }
+          case "NAMESPACE":
+            if (
+              findAnnotation(req.directive.value, context.namespace.annotations)
+            ) {
+              found = true;
+              break dirRequiresLoop;
+            }
+          case "INTERFACE":
+            if (
+              context.interface != undefined &&
+              findAnnotation(
+                req.directive.value,
+                context.interface!.annotations
+              )
+            ) {
+              found = true;
+              break dirRequiresLoop;
+            }
+          case "PARAMETER":
+            if (
+              context.parameter != undefined &&
+              findAnnotation(
+                req.directive.value,
+                context.parameter!.annotations
+              )
+            ) {
+              found = true;
+              break dirRequiresLoop;
+            }
+          case "TYPE":
+            if (
+              context.type != undefined &&
+              findAnnotation(req.directive.value, context.type!.annotations)
+            ) {
+              found = true;
+              break dirRequiresLoop;
+            }
+          case "FIELD":
+            if (
+              context.field != undefined &&
+              findAnnotation(req.directive.value, context.field!.annotations)
+            ) {
+              found = true;
+              break dirRequiresLoop;
+            }
+          case "ENUM":
+            if (
+              context.enum != undefined &&
+              findAnnotation(req.directive.value, context.enum!.annotations)
+            ) {
+              found = true;
+              break dirRequiresLoop;
+            }
+          case "ENUM_VALUE":
+            if (
+              context.enumValue != undefined &&
+              findAnnotation(
+                req.directive.value,
+                context.enumValue!.annotations
+              )
+            ) {
+              found = true;
+              break dirRequiresLoop;
+            }
+          case "UNION":
+            if (
+              context.union != undefined &&
+              findAnnotation(req.directive.value, context.union!.annotations)
+            ) {
+              found = true;
+              break dirRequiresLoop;
+            }
+          case "ALIAS":
+            if (
+              context.alias != undefined &&
+              findAnnotation(req.directive.value, context.alias!.annotations)
+            ) {
+              found = true;
+              break dirRequiresLoop;
+            }
+        }
+      }
+      if (!found) {
+        const locations = req.locations
+          .map((l) => l.value.toLowerCase().replace("_", " "))
+          .join(", ");
+        context.reportError(
+          validationError(
+            annotation,
+            `annotation "${annotation.name.value}" requires "${req.directive.value}" to exist on relative ${locations}`
+          )
+        );
+      }
+    }
+  }
+}
+
+function findAnnotation(name: string, annotations: Annotation[]): boolean {
+  for (let annotation of annotations) {
+    if (annotation.name.value == name) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/deno_dist/rules/valid_directive_locations.ts
+++ b/deno_dist/rules/valid_directive_locations.ts
@@ -1,0 +1,82 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { AbstractVisitor, Context } from "../ast/index.ts";
+import { validationError } from "../error/index.ts";
+
+const validLocationNames = new Set([
+  "NAMESPACE",
+  "INTERFACE",
+  "OPERATION",
+  "PARAMETER",
+  "TYPE",
+  "FIELD",
+  "ENUM",
+  "ENUM_VALUE",
+  "UNION",
+  "ALIAS",
+]);
+
+export class ValidDirectiveLocations extends AbstractVisitor {
+  visitDirective(context: Context): void {
+    const dir = context.directive!;
+    const dirName = dir.name.value;
+    const locationNames = new Set<string>();
+
+    for (let loc of dir.locations) {
+      if (!validLocationNames.has(loc.value)) {
+        context.reportError(
+          validationError(
+            loc,
+            `invalid directive location "${loc.value}" on "${dirName}"`
+          )
+        );
+      }
+      if (locationNames.has(loc.value)) {
+        context.reportError(
+          validationError(
+            loc,
+            `duplicate directive location "${loc.value}" on "${dirName}"`
+          )
+        );
+      }
+      locationNames.add(loc.value);
+    }
+
+    for (let req of dir.requires) {
+      const requireLocationNames = new Set<string>();
+      for (let loc of req.locations) {
+        if (loc.value != "SELF" && !validLocationNames.has(loc.value)) {
+          context.reportError(
+            validationError(
+              loc,
+              `invalid directive location "${loc.value}" on "${dirName}"`
+            )
+          );
+        }
+        if (requireLocationNames.has(loc.value)) {
+          context.reportError(
+            validationError(
+              loc,
+              `duplicate directive location "${loc.value}" on "${dirName}"`
+            )
+          );
+        }
+        requireLocationNames.add(loc.value);
+      }
+    }
+  }
+}

--- a/deno_dist/rules/valid_directive_parameter_types.ts
+++ b/deno_dist/rules/valid_directive_parameter_types.ts
@@ -1,0 +1,74 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import {
+  AbstractVisitor,
+  Context,
+  Type,
+  Kind,
+  DirectiveDefinition,
+  Optional,
+  MapType,
+  ListType,
+  Named,
+} from "../ast/index.ts";
+import { validationError } from "../error/index.ts";
+
+const validTypes = new Set([Kind.TypeDefinition, Kind.EnumDefinition]);
+
+export class ValidDirectiveParameterTypes extends AbstractVisitor {
+  visitDirectiveParameter(context: Context): void {
+    const dir = context.directive!;
+    const param = context.parameter!;
+    this.check(context, dir, param.type);
+  }
+
+  private check(context: Context, dir: DirectiveDefinition, type: Type) {
+    switch (type.getKind()) {
+      case Kind.Optional:
+        const optional = type as Optional;
+        this.check(context, dir, optional.type);
+        break;
+
+      case Kind.Named:
+        const named = type as Named;
+        const typeDef = context.allTypes.get(named.name.value);
+        if (typeDef == undefined) {
+          return;
+        }
+
+        if (!validTypes.has(typeDef.getKind())) {
+          context.reportError(
+            validationError(
+              type,
+              `invalid type used in directive "${dir.name.value}": only Types, Enums and built-in types are allowed`
+            )
+          );
+        }
+        break;
+
+      case Kind.ListType:
+        const listType = type as ListType;
+        this.check(context, dir, listType.type);
+        break;
+
+      case Kind.MapType:
+        const mapType = type as MapType;
+        this.check(context, dir, mapType.valueType);
+        break;
+    }
+  }
+}

--- a/deno_dist/rules/valid_directive_requires.ts
+++ b/deno_dist/rules/valid_directive_requires.ts
@@ -1,0 +1,49 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { AbstractVisitor, Context } from "../ast/index.ts";
+import { validationError } from "../error/index.ts";
+
+const validLocationNames = new Set([
+  "NAMESPACE",
+  "INTERFACE",
+  "OPERATION",
+  "PARAMETER",
+  "TYPE",
+  "FIELD",
+  "ENUM",
+  "ENUM_VALUE",
+  "UNION",
+  "ALIAS",
+]);
+
+export class ValidDirectiveRequires extends AbstractVisitor {
+  visitDirective(context: Context): void {
+    const dir = context.directive!;
+    const dirName = dir.name.value;
+
+    for (let req of dir.requires) {
+      if (!context.directiveMap.has(req.directive.value)) {
+        context.reportError(
+          validationError(
+            req.directive,
+            `unknown required directive "${req.directive.value}" on "${dirName}"`
+          )
+        );
+      }
+    }
+  }
+}

--- a/deno_dist/rules/valid_enum_value_indexes.ts
+++ b/deno_dist/rules/valid_enum_value_indexes.ts
@@ -1,0 +1,38 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { AbstractVisitor, Context } from "../ast/index.ts";
+import { validationError } from "../error/index.ts";
+
+export class ValidEnumValueIndexes extends AbstractVisitor {
+  private parentName: string = "";
+
+  visitEnum(context: Context): void {
+    this.parentName = context.enum!.name.value;
+  }
+  visitEnumValue(context: Context): void {
+    const enumValue = context.enumValue!;
+    const value = enumValue.index.value;
+    if (isNaN(value) || value < 0) {
+      context.reportError(
+        validationError(
+          enumValue.index,
+          `value index "${enumValue.index.value}" in enum "${this.parentName}" must be a non-negative integer`
+        )
+      );
+    }
+  }
+}

--- a/deno_dist/token_kind.ts
+++ b/deno_dist/token_kind.ts
@@ -1,0 +1,74 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * The enum type representing the token kinds values.
+ */
+export enum TokenKind {
+  EOF = 1,
+  BANG,
+  QUESTION,
+  DOLLAR,
+  PAREN_L,
+  PAREN_R,
+  SPREAD,
+  COLON,
+  EQUALS,
+  STAR,
+  AT,
+  BRACKET_L,
+  BRACKET_R,
+  BRACE_L,
+  PIPE,
+  BRACE_R,
+  NAME,
+  NS,
+  INT,
+  FLOAT,
+  STRING,
+  BLOCK_STRING,
+  AMP,
+  SOF,
+  COMMENT,
+}
+
+export const TokenDescription = new Map<number, string>([
+  [TokenKind.EOF, "EOF"],
+  [TokenKind.BANG, "!"],
+  [TokenKind.QUESTION, "?"],
+  [TokenKind.DOLLAR, "$"],
+  [TokenKind.PAREN_L, "("],
+  [TokenKind.PAREN_R, ")"],
+  [TokenKind.SPREAD, "..."],
+  [TokenKind.COLON, ":"],
+  [TokenKind.EQUALS, "="],
+  [TokenKind.STAR, "*"],
+  [TokenKind.AT, "@"],
+  [TokenKind.BRACKET_L, "["],
+  [TokenKind.BRACKET_R, "]"],
+  [TokenKind.BRACE_L, "{"],
+  [TokenKind.PIPE, "|"],
+  [TokenKind.BRACE_R, "}"],
+  [TokenKind.NAME, "Name"],
+  [TokenKind.NS, "NS"],
+  [TokenKind.INT, "Int"],
+  [TokenKind.FLOAT, "Float"],
+  [TokenKind.STRING, "String"],
+  [TokenKind.BLOCK_STRING, "BlockString"],
+  [TokenKind.AMP, "&"],
+  [TokenKind.SOF, "SOF"],
+  [TokenKind.COMMENT, "Comment"],
+]);

--- a/deno_dist/validator.ts
+++ b/deno_dist/validator.ts
@@ -1,0 +1,32 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { Context, Document, MultiVisitor } from "./ast/index.ts";
+import { ApexError } from "./error/index.ts";
+import { ValidationRule } from "./rules/index.ts";
+
+export function validate(
+  doc: Document,
+  ...rules: ValidationRule[]
+): ApexError[] {
+  const context = new Context({});
+
+  const ruleVisitors = rules.map((r) => new r());
+  const visitor = new MultiVisitor(...ruleVisitors);
+
+  doc.accept(context, visitor);
+  return context.getErrors();
+}

--- a/src/ast/mod.ts
+++ b/src/ast/mod.ts
@@ -1,0 +1,17 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export * from "./index.js";

--- a/src/error/mod.ts
+++ b/src/error/mod.ts
@@ -1,0 +1,17 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export * from "./index.js";

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,0 +1,17 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export * from "./index.js";

--- a/src/model/mod.ts
+++ b/src/model/mod.ts
@@ -1,0 +1,17 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export * from "./index.js";

--- a/src/rules/mod.ts
+++ b/src/rules/mod.ts
@@ -1,0 +1,17 @@
+/*
+Copyright 2022 The Apex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export * from "./rules.js";


### PR DESCRIPTION
This PR adds a few `mod.ts` files which is Deno's equivalent to `index.ts/js`. This allows the running of `npc denoify` which produces the `deno_dist` directory suitable for publishing via deno.land.

Outside of the new `mod.ts` files, this PR is largely existing files copied to `deno_dist` with imports renamed from `.js` to `.ts`.